### PR TITLE
feat(BUILT-9): Coach Dashboard Page

### DIFF
--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/App.xaml
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/App.xaml
@@ -15,7 +15,7 @@
             <Color x:Key="Grey">#B1A7A6</Color>
             <Color x:Key="LightGrey">#D3D3D3</Color>
             <Color x:Key="ExtraLightGrey">#F5F3F4</Color>
-
+            <Color x:Key="PageBackground">#E0E0E0</Color>
 
 
 

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/AppShell.xaml
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/AppShell.xaml
@@ -93,18 +93,9 @@
         COACH PAGES
     -->
 
-    <FlyoutItem Title="Workouts" IsVisible="{Binding IsCoach}">
-        <ShellContent Route="CoachWorkoutPage" ContentTemplate="{DataTemplate coachpages:CoachWorkoutPage}" />
+    <FlyoutItem Title="Clients" IsVisible="{Binding IsCoach}">
+        <ShellContent Route="CoachDashboardPage" ContentTemplate="{DataTemplate coachpages:CoachDashboardPage}" />
     </FlyoutItem>
-
-    <FlyoutItem Title="Menu" IsVisible="{Binding IsCoach}">
-        <ShellContent Route="CoachMenuPage" ContentTemplate="{DataTemplate coachpages:CoachMenuPage}" />
-    </FlyoutItem>
-
-    <FlyoutItem Title="Meals" IsVisible="{Binding IsCoach}">
-        <ShellContent Route="CoachMealPage" ContentTemplate="{DataTemplate coachpages:CoachMealPage}" />
-    </FlyoutItem>
-
 
     <!--
         CLIENT PAGES

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/AppShell.xaml.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/AppShell.xaml.cs
@@ -20,6 +20,7 @@ namespace BuiltDifferentMobileApp {
             Routing.RegisterRoute(nameof(CoachMealPage), typeof(CoachMealPage));
             Routing.RegisterRoute(nameof(CoachWorkoutPage), typeof(CoachWorkoutPage));
             Routing.RegisterRoute(nameof(CoachMenuPage), typeof(CoachMenuPage));
+            Routing.RegisterRoute(nameof(CoachDashboardPage), typeof(CoachDashboardPage));
 
             // Client pages
             Routing.RegisterRoute(nameof(ClientMenuPage), typeof(ClientMenuPage));

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/BuiltDifferentMobileApp.csproj
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/BuiltDifferentMobileApp.csproj
@@ -47,6 +47,9 @@
     <EmbeddedResource Update="Views\Coach\AddMealPage.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
+    <EmbeddedResource Update="Views\Coach\CoachDashboardPage.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
     <EmbeddedResource Update="Views\Coach\EditMealPage.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Services/NetworkServices/APIConstants.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Services/NetworkServices/APIConstants.cs
@@ -68,5 +68,9 @@ namespace BuiltDifferentMobileApp.Services.NetworkServices
         public static string GetLoginUri() {
             return $"{BaseAddress}/login";
         }
+
+        public static string GetClientsForCoachId(int coachId) {
+            return $"{BaseAddress}/coach/{coachId}/clients";
+        }
     }
 }

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Services/NetworkServices/NetworkService.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Services/NetworkServices/NetworkService.cs
@@ -33,15 +33,22 @@ namespace BuiltDifferentMobileApp.Services.NetworkServices
          */
 
         public async Task<TResult> GetAsync<TResult>(string uri) {
+            try {
+                HttpResponseMessage response = await httpClient.GetAsync(uri);
 
-            HttpResponseMessage response = await httpClient.GetAsync(uri);
+                string serialized = await response.Content.ReadAsStringAsync();
 
+                if(response.IsSuccessStatusCode) {
+                    var result = JsonConvert.DeserializeObject<TResult>(serialized);
 
-            string serialized = await response.Content.ReadAsStringAsync();
+                    return result;
+                }
 
-            var result = JsonConvert.DeserializeObject<TResult>(serialized);
-
-            return result;
+                return default(TResult);
+            }
+            catch(OperationCanceledException) {
+                return default(TResult);
+            }
 
         }
 

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Coach/CoachDashboardPageViewModel.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Coach/CoachDashboardPageViewModel.cs
@@ -16,8 +16,6 @@ namespace BuiltDifferentMobileApp.ViewModels.Coach {
         private IAccountService accountService = AccountService.Instance;
         private INetworkService<HttpResponseMessage> networkService = NetworkService<HttpResponseMessage>.Instance;
 
-        private int coachId;
-
         private List<Models.Client> originalClients { get; set; }
         public ObservableRangeCollection<Models.Client> Clients { get; set; }
 
@@ -41,8 +39,6 @@ namespace BuiltDifferentMobileApp.ViewModels.Coach {
             RefreshCommand = new AsyncCommand(FetchClients);
             ViewClientsBoardCommand = new AsyncCommand<Models.Client>(ViewClientsBoard);
 
-            coachId = ((Models.Coach)accountService.CurrentUser).id;
-
             FetchClients();
         }
 
@@ -65,6 +61,8 @@ namespace BuiltDifferentMobileApp.ViewModels.Coach {
 
         public async Task FetchClients() {
             IsBusy = true;
+
+            int coachId = ((Models.Coach)accountService.CurrentUser).id;
 
             List<Models.Client> clients = await networkService.GetAsync<List<Models.Client>>(APIConstants.GetClientsForCoachId(coachId));
 

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Coach/CoachDashboardPageViewModel.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Coach/CoachDashboardPageViewModel.cs
@@ -1,0 +1,60 @@
+﻿using BuiltDifferentMobileApp.Services.AccountServices;
+using BuiltDifferentMobileApp.Services.NetworkServices;
+using BuiltDifferentMobileApp.Views.Coach;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Xamarin.CommunityToolkit.ObjectModel;
+using Xamarin.Forms;
+
+namespace BuiltDifferentMobileApp.ViewModels.Coach {
+    public class CoachDashboardPageViewModel : ViewModelBase {
+
+        private IAccountService accountService = AccountService.Instance;
+        private INetworkService<HttpResponseMessage> networkService = NetworkService<HttpResponseMessage>.Instance;
+
+        private int coachId;
+
+        public ObservableRangeCollection<Models.Client> Clients { get; set; }
+
+        public AsyncCommand ViewMyProfileCommand { get; }
+        public AsyncCommand RefreshCommand { get; }
+        public AsyncCommand<Models.Client> ViewClientsBoardCommand { get; }
+
+        public CoachDashboardPageViewModel() {
+            Title = "Clients";
+
+            ViewMyProfileCommand = new AsyncCommand(accountService.ViewMyProfileCommand);
+            RefreshCommand = new AsyncCommand(FetchClients);
+            ViewClientsBoardCommand = new AsyncCommand<Models.Client>(ViewClientsBoard);
+
+            coachId = ((Models.Coach)accountService.CurrentUser).id;
+
+            FetchClients();
+        }
+
+        private async Task ViewClientsBoard(Models.Client client) {
+            if(client == null || IsBusy) return;
+
+            await Shell.Current.GoToAsync($"{nameof(CoachMenuPage)}?ClientId={client.id}&ClientName={client.name}");
+        }
+
+        public async Task FetchClients() {
+            IsBusy = true;
+
+            List<Models.Client> clients = await networkService.GetAsync<List<Models.Client>>(APIConstants.GetClientsForCoachId(coachId));
+
+            if(clients.Count != 0) {
+                Clients = new ObservableRangeCollection<Models.Client>(clients);
+            } else {
+                Clients = new ObservableRangeCollection<Models.Client>();
+            }
+
+            OnPropertyChanged("Clients");
+            IsBusy = false;
+        }
+
+    }
+}

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Coach/CoachDashboardPageViewModel.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Coach/CoachDashboardPageViewModel.cs
@@ -3,6 +3,7 @@ using BuiltDifferentMobileApp.Services.NetworkServices;
 using BuiltDifferentMobileApp.Views.Coach;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
@@ -17,7 +18,17 @@ namespace BuiltDifferentMobileApp.ViewModels.Coach {
 
         private int coachId;
 
+        private List<Models.Client> originalClients { get; set; }
         public ObservableRangeCollection<Models.Client> Clients { get; set; }
+
+        private string searchTerm;
+        public string SearchTerm {
+            get => searchTerm;
+            set {
+                SetProperty(ref searchTerm, value);
+                FilterResults();
+            }
+        }
 
         public AsyncCommand ViewMyProfileCommand { get; }
         public AsyncCommand RefreshCommand { get; }
@@ -35,6 +46,17 @@ namespace BuiltDifferentMobileApp.ViewModels.Coach {
             FetchClients();
         }
 
+        private void FilterResults() {
+            if(originalClients == null) return;
+
+            if(string.IsNullOrWhiteSpace(SearchTerm)) {
+                Clients.ReplaceRange(originalClients);
+                return;
+            }
+
+            Clients.ReplaceRange(originalClients.Where(c => c.name.ToLower().Contains(SearchTerm.ToLower().Trim())));
+        }
+
         private async Task ViewClientsBoard(Models.Client client) {
             if(client == null || IsBusy) return;
 
@@ -47,10 +69,14 @@ namespace BuiltDifferentMobileApp.ViewModels.Coach {
             List<Models.Client> clients = await networkService.GetAsync<List<Models.Client>>(APIConstants.GetClientsForCoachId(coachId));
 
             if(clients.Count != 0) {
+                originalClients = clients;
                 Clients = new ObservableRangeCollection<Models.Client>(clients);
             } else {
+                originalClients = null;
                 Clients = new ObservableRangeCollection<Models.Client>();
             }
+
+            FilterResults();
 
             OnPropertyChanged("Clients");
             IsBusy = false;

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Coach/CoachMealViewModel.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Coach/CoachMealViewModel.cs
@@ -39,13 +39,16 @@ namespace BuiltDifferentMobileApp.ViewModels.Coach
             }
         }
 
+        public string MealPageTitle { get; set; }
+
         private INetworkService<HttpResponseMessage> networkService = NetworkService<HttpResponseMessage>.Instance;
 
         private IAccountService accountService = AccountService.Instance;
 
-        public CoachMealViewModel()
+        public CoachMealViewModel(string clientName, int clientId)
         {
-            clientId = 2;
+            MealPageTitle = $"{clientName} Meal Plan";
+            this.clientId = clientId;
             EditCommand = new AsyncCommand<int>(EditMeal);
             AddCommand = new AsyncCommand(AddMeal);
 

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Coach/CoachMenuPageViewModel.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Coach/CoachMenuPageViewModel.cs
@@ -12,12 +12,9 @@ using Xamarin.Forms;
 namespace BuiltDifferentMobileApp.ViewModels.Coach {
     public class CoachMenuPageViewModel : ViewModelBase {
 
-        private IAccountService accountService = AccountService.Instance;
-
         public AsyncCommand ViewMyProfileCommand { get; }
 
         public CoachMenuPageViewModel() {
-            ViewMyProfileCommand = new AsyncCommand(accountService.ViewMyProfileCommand);
         }
 
     }

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Coach/CoachWorkoutViewModel.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Coach/CoachWorkoutViewModel.cs
@@ -36,7 +36,7 @@ namespace BuiltDifferentMobileApp.ViewModels.Coach
 
         public CoachWorkoutViewModel(string clientName, int clientId)
         {
-            WorkoutPageTitle = $"{clientName} Meal Plan";
+            WorkoutPageTitle = $"{clientName} Workout Plan";
             this.clientId = clientId;
             Day = DateTime.Now.Date;
             EditCommand = new AsyncCommand<int>(EditWorkout);

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Coach/CoachWorkoutViewModel.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Coach/CoachWorkoutViewModel.cs
@@ -29,16 +29,20 @@ namespace BuiltDifferentMobileApp.ViewModels.Coach
                 
             }
         }
+
+        public string WorkoutPageTitle { get; set; }
+
         private INetworkService<HttpResponseMessage> networkService = NetworkService<HttpResponseMessage>.Instance;
-        public CoachWorkoutViewModel()
+
+        public CoachWorkoutViewModel(string clientName, int clientId)
         {
-            clientId = 2;
+            WorkoutPageTitle = $"{clientName} Meal Plan";
+            this.clientId = clientId;
             Day = DateTime.Now.Date;
             EditCommand = new AsyncCommand<int>(EditWorkout);
             AddCommand = new AsyncCommand(AddWorkout);
 
             GetWorkouts();
-
         }
 
         public async Task GetWorkouts()

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Login/LoginPageViewModel.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Login/LoginPageViewModel.cs
@@ -77,7 +77,7 @@ namespace BuiltDifferentMobileApp.ViewModels.Login {
                     await Shell.Current.GoToAsync($"//{nameof(AdminMenuPage)}");
                 }
                 else if(accountService.CurrentUserRole == AccountConstants.Coach) {
-                    await Shell.Current.GoToAsync($"//{nameof(CoachMenuPage)}");
+                    await Shell.Current.GoToAsync($"//{nameof(CoachDashboardPage)}");
                 }
                 else if(accountService.CurrentUserRole == AccountConstants.Client) {
                     await Shell.Current.GoToAsync($"//{nameof(ClientMenuPage)}");

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/CoachDashboardPage.xaml
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/CoachDashboardPage.xaml
@@ -23,7 +23,7 @@
             <StackLayout BackgroundColor="{StaticResource PageBackground}" Padding="0,12,0,0" Margin="0">
                 <Label Text="Your Clients" FontSize="26" FontAttributes="Bold" HorizontalTextAlignment="Center" TextColor="{StaticResource DarkGrey}"/>
                 
-                <SearchBar Placeholder="Search client"/>
+                <SearchBar Placeholder="Search client" Text="{Binding SearchTerm}"/>
                 
                 <CollectionView ItemsSource="{Binding Clients}"
                                 ItemSizingStrategy="MeasureAllItems">

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/CoachDashboardPage.xaml
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/CoachDashboardPage.xaml
@@ -1,0 +1,84 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:viewmodels="clr-namespace:BuiltDifferentMobileApp.ViewModels.Coach"
+             x:Class="BuiltDifferentMobileApp.Views.Coach.CoachDashboardPage"
+             Title="{Binding Title}"
+             x:Name="MyCoachDashboardPage">
+
+    <ContentPage.BindingContext>
+        <viewmodels:CoachDashboardPageViewModel />
+    </ContentPage.BindingContext>
+
+    <ContentPage.ToolbarItems>
+        <ToolbarItem Text="Profile" Command="{Binding ViewMyProfileCommand}">
+            <ToolbarItem.IconImageSource>
+                <FontImageSource FontFamily="FAS" Glyph="&#xf2bd;"/>
+            </ToolbarItem.IconImageSource>        </ToolbarItem>
+    </ContentPage.ToolbarItems>
+
+    <ContentPage.Content>
+        <RefreshView IsRefreshing="{Binding IsBusy}"
+                     Command="{Binding RefreshCommand}">
+            <StackLayout BackgroundColor="{StaticResource PageBackground}" Padding="0,12,0,0" Margin="0">
+                <Label Text="Your Clients" FontSize="26" FontAttributes="Bold" HorizontalTextAlignment="Center" TextColor="{StaticResource DarkGrey}"/>
+                
+                <SearchBar Placeholder="Search client"/>
+                
+                <CollectionView ItemsSource="{Binding Clients}"
+                                ItemSizingStrategy="MeasureAllItems">
+
+                    <CollectionView.EmptyView>
+                        <Label Text="No clients." />
+                    </CollectionView.EmptyView>
+
+                    <CollectionView.ItemTemplate>
+                        <DataTemplate>
+                            <StackLayout>
+                                <Frame BorderColor="Black" BackgroundColor="White" CornerRadius="0" Margin="0" Padding="10">
+                                    <Grid>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition />
+                                        </Grid.RowDefinitions>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="200"/>
+                                            <ColumnDefinition />
+                                            <ColumnDefinition />
+                                        </Grid.ColumnDefinitions>
+
+                                        <StackLayout Grid.Row="0" Grid.Column="0" Orientation="Horizontal">
+                                            <Image Source="https://pngset.com/images/katie-notopoulos-katienotopoulos-i-write-about-tech-round-profile-image-placeholder-text-number-symbol-word-transparent-png-201415.png" HeightRequest="40"/>
+                                            <Label Text="{Binding name}" LineBreakMode="TailTruncation" VerticalOptions="Center" FontSize="Large"/>
+                                        </StackLayout>
+
+                                        <Label Grid.Row="0" Grid.Column="1" Text="69%" HorizontalOptions="Center" LineBreakMode="TailTruncation" VerticalOptions="Center" FontSize="Large"/>
+                                        <Button Grid.Row="0" Grid.Column="2" Text="Board"
+                                                Command="{Binding Source={x:Reference MyCoachDashboardPage}, Path=BindingContext.ViewClientsBoardCommand}" CommandParameter="{Binding .}" 
+                                                CornerRadius="8" HeightRequest="40" VerticalOptions="Center" HorizontalOptions="EndAndExpand"/>
+                                    </Grid>
+                                </Frame>
+                            </StackLayout>
+                        </DataTemplate>
+                    </CollectionView.ItemTemplate>
+
+                    <CollectionView.Header>
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition />
+                            </Grid.RowDefinitions>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="200"/>
+                                <ColumnDefinition />
+                                <ColumnDefinition />
+                            </Grid.ColumnDefinitions>
+
+                            <Label Text="Name" Grid.Row="0" Grid.Column="0" HorizontalOptions="Center" FontAttributes="Bold"/>
+                            <Label Text="Daily Progress" Grid.Row="0" Grid.Column="1" HorizontalOptions="Center" FontAttributes="Bold"/>
+                        </Grid>
+                    </CollectionView.Header>
+
+                </CollectionView>
+            </StackLayout>
+        </RefreshView>
+    </ContentPage.Content>
+</ContentPage>

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/CoachDashboardPage.xaml
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/CoachDashboardPage.xaml
@@ -6,10 +6,6 @@
              Title="{Binding Title}"
              x:Name="MyCoachDashboardPage">
 
-    <ContentPage.BindingContext>
-        <viewmodels:CoachDashboardPageViewModel />
-    </ContentPage.BindingContext>
-
     <ContentPage.ToolbarItems>
         <ToolbarItem Text="Profile" Command="{Binding ViewMyProfileCommand}">
             <ToolbarItem.IconImageSource>

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/CoachDashboardPage.xaml.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/CoachDashboardPage.xaml.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace BuiltDifferentMobileApp.Views.Coach {
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class CoachDashboardPage : ContentPage {
+        public CoachDashboardPage() {
+            InitializeComponent();
+        }
+    }
+}

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/CoachDashboardPage.xaml.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/CoachDashboardPage.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using BuiltDifferentMobileApp.ViewModels.Coach;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -12,6 +13,11 @@ namespace BuiltDifferentMobileApp.Views.Coach {
     public partial class CoachDashboardPage : ContentPage {
         public CoachDashboardPage() {
             InitializeComponent();
+        }
+
+        protected override void OnAppearing() {
+            base.OnAppearing();
+            BindingContext = new CoachDashboardPageViewModel();
         }
     }
 }

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/CoachDashboardPage.xaml.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/CoachDashboardPage.xaml.cs
@@ -13,11 +13,15 @@ namespace BuiltDifferentMobileApp.Views.Coach {
     public partial class CoachDashboardPage : ContentPage {
         public CoachDashboardPage() {
             InitializeComponent();
+            BindingContext = new CoachDashboardPageViewModel();
         }
 
-        protected override void OnAppearing() {
+        protected async override void OnAppearing() {
             base.OnAppearing();
-            BindingContext = new CoachDashboardPageViewModel();
+            if(BindingContext != null) {
+                var viewModel = (CoachDashboardPageViewModel)BindingContext;
+                await viewModel.FetchClients();
+            }
         }
     }
 }

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/CoachMealPage.xaml
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/CoachMealPage.xaml
@@ -5,10 +5,10 @@
              x:Class="BuiltDifferentMobileApp.Views.Coach.CoachMealPage"
               xmlns:viewmodels="clr-namespace:BuiltDifferentMobileApp.ViewModels"
              x:Name="TheMealPage"
-             >
+             Title="Meals">
     <ContentPage.Content>
         <StackLayout Margin="5,0,5,0">
-            <Label Margin="5,20,5,10" AutomationId="MealPageTitle" Text="Olivier's Meal Plan"  FontSize="35"
+            <Label Margin="5,20,5,10" AutomationId="MealPageTitle" Text="{Binding MealPageTitle}"  FontSize="35"
                    FontAttributes="Bold" HorizontalTextAlignment="Center"/>
             <DatePicker HorizontalOptions="Center" Date="{Binding Day}"/>
             <Button Text="Add" AutomationId="AddButton" CornerRadius="12" Margin="300,10,30,10" Command="{Binding AddCommand}" />

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/CoachMealPage.xaml.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/CoachMealPage.xaml.cs
@@ -17,7 +17,6 @@ namespace BuiltDifferentMobileApp.Views.Coach
         public CoachMealPage()
         {
             InitializeComponent();
-            BindingContext = new CoachMealViewModel();
         }
 
         protected override async void OnAppearing()

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/CoachMenuPage.xaml
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/CoachMenuPage.xaml
@@ -4,21 +4,7 @@
              x:Class="BuiltDifferentMobileApp.Views.Coach.CoachMenuPage"
             xmlns:mypages="clr-namespace:BuiltDifferentMobileApp.Views.Coach;assembly=BuiltDifferentMobileApp"
             xmlns:viewmodels="clr-namespace:BuiltDifferentMobileApp.ViewModels.Coach"
-            BackgroundColor="#660708" BarBackgroundColor="#660708">
+            BackgroundColor="#660708" BarBackgroundColor="#660708"
+            Title="{Binding Title}">
 
-    <TabbedPage.BindingContext>
-        <viewmodels:CoachMenuPageViewModel />
-    </TabbedPage.BindingContext>
-    
-    <TabbedPage.ToolbarItems>
-        <ToolbarItem Text="Profile" Command="{Binding ViewMyProfileCommand}">
-            <ToolbarItem.IconImageSource>
-                <FontImageSource FontFamily="FAS" Glyph="&#xf2bd;"/>
-            </ToolbarItem.IconImageSource>        </ToolbarItem>
-    </TabbedPage.ToolbarItems>
-    
-    <TabbedPage.Children>
-        <mypages:CoachMealPage Title="Meals"/>
-        <mypages:CoachWorkoutPage Title="Workouts"/>
-        </TabbedPage.Children>
 </TabbedPage>

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/CoachMenuPage.xaml.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/CoachMenuPage.xaml.cs
@@ -23,6 +23,7 @@ namespace BuiltDifferentMobileApp.Views.Coach
         {
             InitializeComponent();
             BindingContext = new CoachMenuPageViewModel();
+            Children.Clear();
         }
 
         protected override void OnAppearing() {

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/CoachMenuPage.xaml.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/CoachMenuPage.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using BuiltDifferentMobileApp.ViewModels.Coach;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -10,12 +11,43 @@ using Xamarin.Forms.Xaml;
 namespace BuiltDifferentMobileApp.Views.Coach
 {
     [XamlCompilation(XamlCompilationOptions.Compile)]
+    [QueryProperty(nameof(ClientId), nameof(ClientId))]
+    [QueryProperty(nameof(ClientName), nameof(ClientName))]
     public partial class CoachMenuPage : TabbedPage
     {
+
+        public int ClientId { get; set; }
+        public string ClientName { get; set; }
+
         public CoachMenuPage()
         {
             InitializeComponent();
+            BindingContext = new CoachMenuPageViewModel();
         }
-        
+
+        protected override void OnAppearing() {
+            base.OnAppearing();
+            if(Children.Count != 2) {
+                if(ClientName.EndsWith("s")) {
+                    ClientName += "'";
+                } else {
+                    ClientName += "'s";
+                }
+
+                ((CoachMenuPageViewModel)BindingContext).Title = $"{ClientName} board";
+
+                var workoutPage = new CoachWorkoutPage {
+                    BindingContext = new CoachWorkoutViewModel(ClientName, ClientId)
+                };
+
+                var mealPage = new CoachMealPage {
+                    BindingContext = new CoachMealViewModel(ClientName, ClientId)
+                };
+
+                Children.Add(workoutPage);
+                Children.Add(mealPage);
+            }
+        }
+
     }
 }

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/CoachWorkoutPage.xaml
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/CoachWorkoutPage.xaml
@@ -3,10 +3,11 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
              xmlns:behaviors="http://xamarin.com/schemas/2020/toolkit"
              x:Class="BuiltDifferentMobileApp.Views.Coach.CoachWorkoutPage"
-             x:Name="TheWorkoutPage">
+             x:Name="TheWorkoutPage"
+             Title="Workouts">
     <ContentPage.Content >
         <StackLayout Margin="5,0,5,0">
-            <Label Margin="5,20,5,10" AutomationId="WorkoutTitle" Text="Olivier's Workout Plan"  FontSize="35"
+            <Label Margin="5,20,5,10" AutomationId="WorkoutTitle" Text="{Binding WorkoutPageTitle}"  FontSize="35"
                    FontAttributes="Bold" HorizontalTextAlignment="Center"/>
 
 

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/CoachWorkoutPage.xaml.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/CoachWorkoutPage.xaml.cs
@@ -17,7 +17,6 @@ namespace BuiltDifferentMobileApp.Views.Coach
         public CoachWorkoutPage()
         {
             InitializeComponent();
-            BindingContext = new CoachWorkoutViewModel();
         }
 
         protected async override void OnAppearing()

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Login/LoginPage.xaml.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Login/LoginPage.xaml.cs
@@ -33,10 +33,9 @@ namespace BuiltDifferentMobileApp.Views.Login {
 
         protected override void OnAppearing() {
             base.OnAppearing();
+            accountService.RemoveCurrentUser();
+            networkService.RemoveJWTToken();
             if(BindingContext != null) {
-                accountService.RemoveCurrentUser();
-                networkService.RemoveJWTToken();
-
                 var viewModel = (LoginPageViewModel)BindingContext;
                 viewModel.Email = accountService.CurrentUserEmail;
                 viewModel.Password = "";


### PR DESCRIPTION
JIRA: [BUILT-9](https://champlainsaintlambert.atlassian.net/browse/BUILT-9?atlOrigin=eyJpIjoiMjlmNTIzYzYzNzgxNDA4ZjkxYzU0ZDcyNTk5MWNkMzUiLCJwIjoiaiJ9)

## Context
This story adds a page filled with clients assigned to the logged in coach. The coach can then select which client's plan they want to modify.

## Changes
- New Dashboard page with a searchable collection view
- Moved definition of tab page children to the Menu page xaml.cs
- Viewmodels for the tabbed pages are defined in the Menu page xaml.cs
- **Removed workouts & meals page from flyout (this breaks end-to-end tests)**
- Changed ClientID to be received as a query parameter for the tabbed pages

## Relevant screenshots
### Note: Daily progress is a placeholder
![image](https://user-images.githubusercontent.com/55009009/147154555-289c1843-accb-4524-aa00-d294fa3219b9.png)
![image](https://user-images.githubusercontent.com/55009009/147154613-705c3aec-7e02-4c72-8f56-9fe248d4eb15.png)

