### PR TITLE
feat(BUILT-23): Pending coach approval list

### DIFF
--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/AppShell.xaml
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/AppShell.xaml
@@ -112,6 +112,10 @@
     <FlyoutItem Title="Menu" IsVisible="{Binding IsAdmin}">
         <ShellContent Route="AdminMenuPage" ContentTemplate="{DataTemplate adminpages:AdminMenuPage}" />
     </FlyoutItem>
+    
+    <FlyoutItem Title="Pending Coaches" IsVisible="{Binding IsAdmin}">
+        <ShellContent Route="AdminCoachApprovalPage" ContentTemplate="{DataTemplate adminpages:AdminCoachApprovalPage}" />
+    </FlyoutItem>
 
     <!--
         LOGOUT

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/AppShell.xaml.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/AppShell.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using BuiltDifferentMobileApp.ViewModels;
+using BuiltDifferentMobileApp.Views.Admin;
 using BuiltDifferentMobileApp.Views.Client;
 using BuiltDifferentMobileApp.Views.Coach;
 using BuiltDifferentMobileApp.Views.Login;
@@ -11,6 +12,10 @@ namespace BuiltDifferentMobileApp {
     public partial class AppShell : Xamarin.Forms.Shell {
         public AppShell() {
             InitializeComponent();
+
+            // Admin pages
+            Routing.RegisterRoute(nameof(AdminCoachApprovalPage), typeof(AdminCoachApprovalPage));
+            Routing.RegisterRoute(nameof(AdminMenuPage), typeof(AdminMenuPage));
 
             // Coach pages
             Routing.RegisterRoute(nameof(AddWorkoutPage), typeof(AddWorkoutPage));

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/AppShell.xaml.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/AppShell.xaml.cs
@@ -14,6 +14,7 @@ namespace BuiltDifferentMobileApp {
             InitializeComponent();
 
             // Admin pages
+            Routing.RegisterRoute(nameof(AdminCoachApprovalProfilePage), typeof(AdminCoachApprovalProfilePage));
             Routing.RegisterRoute(nameof(AdminCoachApprovalPage), typeof(AdminCoachApprovalPage));
             Routing.RegisterRoute(nameof(AdminMenuPage), typeof(AdminMenuPage));
 

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Models/Coach.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Models/Coach.cs
@@ -11,8 +11,10 @@ namespace BuiltDifferentMobileApp.Models {
         public bool isAvailable { get; set; }
         public bool offersMeal { get; set; }
         public bool offersWorkout { get; set; }
-        public string certification { get; set; }
+        public int certificationId { get; set; }
         public string gender { get; set; }
         public bool isVerified { get; set; }
+        public string description { get; set; }
+        public double pricing { get; set; }
     }
 }

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Services/NetworkServices/APIConstants.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Services/NetworkServices/APIConstants.cs
@@ -86,5 +86,9 @@ namespace BuiltDifferentMobileApp.Services.NetworkServices
         public static string GetRegisterNewAccountUri() {
             return $"{BaseAddress}/register";
         }
+
+        public static string GetPendingCoachesUri() {
+            return $"{BaseAddress}/coaches/pending";
+        }
     }
 }

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Services/NetworkServices/APIConstants.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Services/NetworkServices/APIConstants.cs
@@ -90,5 +90,9 @@ namespace BuiltDifferentMobileApp.Services.NetworkServices
         public static string GetPendingCoachesUri() {
             return $"{BaseAddress}/coaches/pending";
         }
+
+        public static string GetCoachByIdUri(int coachId) {
+            return $"{BaseAddress}/coaches/{coachId}";
+        }
     }
 }

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Admin/AdminCoachApprovalPageViewModel.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Admin/AdminCoachApprovalPageViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using BuiltDifferentMobileApp.Services.NetworkServices;
+using BuiltDifferentMobileApp.Views.Admin;
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
@@ -13,18 +14,30 @@ namespace BuiltDifferentMobileApp.ViewModels.Admin {
         private INetworkService<HttpResponseMessage> networkService = NetworkService<HttpResponseMessage>.Instance;
 
         public ObservableRangeCollection<Models.Coach> Coaches { get; set; }
+        public Models.Coach SelectedCoach { get; set; }
 
         public AsyncCommand RefreshCommand { get; set; }
+        public AsyncCommand CoachSelectedCommand { get; set; }
 
         public AdminCoachApprovalPageViewModel() {
-            Title = "Pending Approvals";
+            Title = "Pending Coaches";
 
             RefreshCommand = new AsyncCommand(FetchPendingCoaches);
+            CoachSelectedCommand = new AsyncCommand(CoachSelected);
 
             FetchPendingCoaches();
         }
 
-        private async Task FetchPendingCoaches() {
+        private async Task CoachSelected() {
+            if(SelectedCoach == null) return;
+
+            var route = $"{nameof(AdminCoachApprovalProfilePage)}?CoachId={SelectedCoach.id}";
+            await Shell.Current.GoToAsync(route);
+
+            SelectedCoach = null;
+        }
+
+        public async Task FetchPendingCoaches() {
             IsBusy = true;
 
             var coaches = await networkService.GetAsync<List<Models.Coach>>(APIConstants.GetPendingCoachesUri());

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Admin/AdminCoachApprovalPageViewModel.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Admin/AdminCoachApprovalPageViewModel.cs
@@ -1,0 +1,44 @@
+﻿using BuiltDifferentMobileApp.Services.NetworkServices;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Xamarin.CommunityToolkit.ObjectModel;
+using Xamarin.Forms;
+
+namespace BuiltDifferentMobileApp.ViewModels.Admin {
+    public class AdminCoachApprovalPageViewModel : ViewModelBase {
+
+        private INetworkService<HttpResponseMessage> networkService = NetworkService<HttpResponseMessage>.Instance;
+
+        public ObservableRangeCollection<Models.Coach> Coaches { get; set; }
+
+        public AsyncCommand RefreshCommand { get; set; }
+
+        public AdminCoachApprovalPageViewModel() {
+            Title = "Pending Approvals";
+
+            RefreshCommand = new AsyncCommand(FetchPendingCoaches);
+
+            FetchPendingCoaches();
+        }
+
+        private async Task FetchPendingCoaches() {
+            IsBusy = true;
+
+            var coaches = await networkService.GetAsync<List<Models.Coach>>(APIConstants.GetPendingCoachesUri());
+
+            if(coaches.Count > 0) {
+                Coaches = new ObservableRangeCollection<Models.Coach>(coaches);
+            } else {
+                Coaches = new ObservableRangeCollection<Models.Coach>();
+            }
+
+            OnPropertyChanged("Coaches");
+
+            IsBusy = false;
+        }
+
+    }
+}

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Admin/AdminCoachApprovalProfilePageViewModel.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Admin/AdminCoachApprovalProfilePageViewModel.cs
@@ -1,0 +1,84 @@
+﻿using BuiltDifferentMobileApp.Services.NetworkServices;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Xamarin.CommunityToolkit.ObjectModel;
+using Xamarin.Forms;
+
+namespace BuiltDifferentMobileApp.ViewModels.Admin {
+    public class AdminCoachApprovalProfilePageViewModel : ViewModelBase {
+
+        private INetworkService<HttpResponseMessage> networkService = NetworkService<HttpResponseMessage>.Instance;
+
+        public int CoachId { get; set; }
+        public string DenyButtonText { get; set; }
+        public string ApproveButtonText { get; set; }
+
+        public string Name { get; set; }
+        public string Gender { get; set; }
+        public string PlansOffered { get; set; }
+        public string Description { get; set; }
+
+        public AsyncCommand RefreshCommand { get; set; }
+        public AsyncCommand<string> RespondToCoachApplicationCommand { get; set; }
+
+        public AdminCoachApprovalProfilePageViewModel(int coachId) {
+            Title = "Coach Application";
+            CoachId = coachId;
+            DenyButtonText = "Deny";
+            ApproveButtonText = "Approve";
+
+            RefreshCommand = new AsyncCommand(FetchCoachInformation);
+            RespondToCoachApplicationCommand = new AsyncCommand<string>(RespondToCoachApplication);
+
+            FetchCoachInformation();
+        }
+
+        private async Task RespondToCoachApplication(string action) {
+            // TODO: actually respond to coach application
+            if(action == ApproveButtonText) {
+                await Application.Current.MainPage.DisplayAlert("(PLACEHOLDER) Confirm action", "Are you sure you want to approve this coach?", "Confirm", "Cancel");
+            }
+            else {
+                await Application.Current.MainPage.DisplayAlert("(PLACEHOLDER) Confirm action", "Are you sure you want to deny this coach ?", "Confirm", "Cancel");
+            }
+        }
+
+        public async Task FetchCoachInformation() {
+            IsBusy = true;
+
+            var coach = await networkService.GetAsync<Models.Coach>(APIConstants.GetCoachByIdUri(CoachId));
+
+            if(coach == null) {
+                await Application.Current.MainPage.DisplayAlert("Could not load coach's profile!", "Returning to previous page", "OK");
+                await Shell.Current.GoToAsync("..");
+                return;
+            }
+
+            Name = coach.name;
+            Description = coach.description;
+            Gender = coach.gender;
+
+            PlansOffered = "Plans: ";
+            if(coach.offersMeal && coach.offersWorkout) {
+                PlansOffered += "Workouts, Meals";
+            }
+            else if(coach.offersMeal && !coach.offersWorkout) {
+                PlansOffered += "Meals";
+            }
+            else if(!coach.offersMeal && coach.offersWorkout) {
+                PlansOffered += "Workouts";
+            }
+
+            OnPropertyChanged("Name");
+            OnPropertyChanged("Gender");
+            OnPropertyChanged("Description");
+            OnPropertyChanged("PlansOffered");
+
+            IsBusy = false;
+        }
+
+    }
+}

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Profile/MyProfilePageCoachViewModel.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Profile/MyProfilePageCoachViewModel.cs
@@ -13,7 +13,7 @@ namespace BuiltDifferentMobileApp.ViewModels.Profile {
         public bool IsAvailable { get; set; }
         public bool OffersMeal { get; set; }
         public bool OffersWorkout { get; set; }
-        public string Certification { get; set; }
+        public int CertificationId { get; set; }
         public string Gender { get; set; }
         public bool IsVerified { get; set; }
 
@@ -27,7 +27,7 @@ namespace BuiltDifferentMobileApp.ViewModels.Profile {
             IsAvailable = user.isAvailable;
             OffersMeal = user.offersMeal;
             OffersWorkout = user.offersWorkout;
-            Certification = user.certification;
+            CertificationId = user.certificationId;
             Gender = user.gender;
             IsVerified = user.isVerified;
         }

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Admin/AdminCoachApprovalPage.xaml
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Admin/AdminCoachApprovalPage.xaml
@@ -1,0 +1,54 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:viewmodels="clr-namespace:BuiltDifferentMobileApp.ViewModels.Admin"
+             x:Class="BuiltDifferentMobileApp.Views.Admin.AdminCoachApprovalPage"
+             Title="{Binding Title}">
+
+    <ContentPage.BindingContext>
+        <viewmodels:AdminCoachApprovalPageViewModel />
+    </ContentPage.BindingContext>
+    
+    <ContentPage.Content>
+        <RefreshView IsRefreshing="{Binding IsBusy}"
+                     Command="{Binding RefreshCommand}">
+            <StackLayout BackgroundColor="{StaticResource PageBackground}" Padding="0,12,0,0" Margin="0">
+                <Label Text="Your Clients" FontSize="26" FontAttributes="Bold" HorizontalTextAlignment="Center" TextColor="{StaticResource DarkGrey}"/>
+
+                <CollectionView ItemsSource="{Binding Coaches}"
+                                ItemSizingStrategy="MeasureAllItems">
+
+                    <CollectionView.EmptyView>
+                        <Label Text="No pending coaches." />
+                    </CollectionView.EmptyView>
+
+                    <CollectionView.ItemTemplate>
+                        <DataTemplate>
+                            <StackLayout>
+                                <Frame BorderColor="Black" BackgroundColor="White" CornerRadius="0" Margin="0" Padding="10">
+                                    <Grid>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition />
+                                        </Grid.RowDefinitions>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="200"/>
+                                            <ColumnDefinition />
+                                            <ColumnDefinition />
+                                        </Grid.ColumnDefinitions>
+
+                                        <StackLayout Grid.Row="0" Grid.Column="0" Orientation="Horizontal">
+                                            <Image Source="https://pngset.com/images/katie-notopoulos-katienotopoulos-i-write-about-tech-round-profile-image-placeholder-text-number-symbol-word-transparent-png-201415.png" HeightRequest="40"/>
+                                            <Label Text="{Binding name}" LineBreakMode="TailTruncation" VerticalOptions="Center" FontSize="Large"/>
+                                        </StackLayout>
+
+                                    </Grid>
+                                </Frame>
+                            </StackLayout>
+                        </DataTemplate>
+                    </CollectionView.ItemTemplate>
+
+                </CollectionView>
+            </StackLayout>
+        </RefreshView>
+    </ContentPage.Content>
+</ContentPage>

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Admin/AdminCoachApprovalPage.xaml
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Admin/AdminCoachApprovalPage.xaml
@@ -1,25 +1,23 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:viewmodels="clr-namespace:BuiltDifferentMobileApp.ViewModels.Admin"
              x:Class="BuiltDifferentMobileApp.Views.Admin.AdminCoachApprovalPage"
              Title="{Binding Title}">
 
-    <ContentPage.BindingContext>
-        <viewmodels:AdminCoachApprovalPageViewModel />
-    </ContentPage.BindingContext>
-    
     <ContentPage.Content>
         <RefreshView IsRefreshing="{Binding IsBusy}"
                      Command="{Binding RefreshCommand}">
             <StackLayout BackgroundColor="{StaticResource PageBackground}" Padding="0,12,0,0" Margin="0">
-                <Label Text="Your Clients" FontSize="26" FontAttributes="Bold" HorizontalTextAlignment="Center" TextColor="{StaticResource DarkGrey}"/>
+                <Label Text="Requests" FontSize="26" FontAttributes="Bold" HorizontalTextAlignment="Center" TextColor="{StaticResource DarkGrey}"/>
 
                 <CollectionView ItemsSource="{Binding Coaches}"
-                                ItemSizingStrategy="MeasureAllItems">
+                                ItemSizingStrategy="MeasureAllItems"
+                                SelectedItem="{Binding SelectedCoach}"
+                                SelectionMode="Single"
+                                SelectionChangedCommand="{Binding CoachSelectedCommand}">
 
                     <CollectionView.EmptyView>
-                        <Label Text="No pending coaches." />
+                        <Label Text="No pending coach requests." />
                     </CollectionView.EmptyView>
 
                     <CollectionView.ItemTemplate>
@@ -31,16 +29,15 @@
                                             <RowDefinition />
                                         </Grid.RowDefinitions>
                                         <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="200"/>
-                                            <ColumnDefinition />
+                                            <ColumnDefinition Width="350"/>
                                             <ColumnDefinition />
                                         </Grid.ColumnDefinitions>
 
                                         <StackLayout Grid.Row="0" Grid.Column="0" Orientation="Horizontal">
-                                            <Image Source="https://pngset.com/images/katie-notopoulos-katienotopoulos-i-write-about-tech-round-profile-image-placeholder-text-number-symbol-word-transparent-png-201415.png" HeightRequest="40"/>
+                                            <Image Source="https://st3.depositphotos.com/6672868/13701/v/600/depositphotos_137014128-stock-illustration-user-profile-icon.jpg" HeightRequest="40"/>
                                             <Label Text="{Binding name}" LineBreakMode="TailTruncation" VerticalOptions="Center" FontSize="Large"/>
                                         </StackLayout>
-
+                                        <Image Grid.Row="0" Grid.Column="1" Source="icon_about.png" VerticalOptions="Center" HorizontalOptions="EndAndExpand"/>
                                     </Grid>
                                 </Frame>
                             </StackLayout>

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Admin/AdminCoachApprovalPage.xaml.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Admin/AdminCoachApprovalPage.xaml.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace BuiltDifferentMobileApp.Views.Admin {
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class AdminCoachApprovalPage : ContentPage {
+        public AdminCoachApprovalPage() {
+            InitializeComponent();
+        }
+    }
+}

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Admin/AdminCoachApprovalPage.xaml.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Admin/AdminCoachApprovalPage.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using BuiltDifferentMobileApp.ViewModels.Admin;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -12,6 +13,15 @@ namespace BuiltDifferentMobileApp.Views.Admin {
     public partial class AdminCoachApprovalPage : ContentPage {
         public AdminCoachApprovalPage() {
             InitializeComponent();
+            BindingContext = new AdminCoachApprovalPageViewModel();
+        }
+
+        protected async override void OnAppearing() {
+            base.OnAppearing();
+            if(BindingContext != null) {
+                var viewModel = (AdminCoachApprovalPageViewModel)BindingContext;
+                await viewModel.FetchPendingCoaches();
+            }
         }
     }
 }

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Admin/AdminCoachApprovalProfilePage.xaml
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Admin/AdminCoachApprovalProfilePage.xaml
@@ -1,0 +1,67 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:admin="clr-namespace:BuiltDifferentMobileApp.ViewModels.Admin"
+             x:DataType="admin:AdminCoachApprovalProfilePageViewModel"
+             x:Class="BuiltDifferentMobileApp.Views.Admin.AdminCoachApprovalProfilePage"
+             Title="{Binding Title}">
+    <ContentPage.Content>
+        <RefreshView IsRefreshing="{Binding IsBusy}"
+                     Command="{Binding RefreshCommand}">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition />
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition />
+                </Grid.RowDefinitions>
+
+                <ScrollView Grid.Row="0" Grid.Column="0">
+                    <Grid BackgroundColor="{StaticResource PageBackground}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition />
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="350"/>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="60" />
+                        </Grid.RowDefinitions>
+
+                        <Image Source="https://st3.depositphotos.com/6672868/13701/v/600/depositphotos_137014128-stock-illustration-user-profile-icon.jpg"
+                               Aspect="Fill"
+                               Grid.Row="0" Grid.Column="0"/>
+
+                        <Frame Grid.Row="1" Grid.Column="0" BackgroundColor="{StaticResource PageBackground}" BorderColor="Transparent">
+                            <StackLayout Spacing="6">
+                                <StackLayout Spacing="0">
+                                    <Label Text="{Binding Name}" FontSize="Title" TextColor="{StaticResource Black}"/>
+                                    <StackLayout Orientation="Horizontal">
+                                        <Label Text="{Binding Gender, StringFormat='{}{0},'}" FontSize="Subtitle" />
+                                        <Label Text="{Binding PlansOffered}" FontSize="Subtitle" />
+                                    </StackLayout>
+                                </StackLayout>
+                                <Label Text="{Binding Description}" FontSize="Title"/>
+                                <Button Text="TEMP VIEW CERTIFICATION BTN" />
+                            </StackLayout>
+                        </Frame>
+                    </Grid>
+                </ScrollView>
+
+                <Frame Grid.Row="0" Grid.Column="0" VerticalOptions="EndAndExpand" BackgroundColor="#232323" CornerRadius="0" Padding="10">
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition />
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition />
+                            <ColumnDefinition />
+                        </Grid.ColumnDefinitions>
+
+                        <Button Command="{Binding RespondToCoachApplicationCommand}" Text="{Binding DenyButtonText}" CommandParameter="Deny" Grid.Row="0" Grid.Column="0"/>
+                        <Button Command="{Binding RespondToCoachApplicationCommand}" Text="{Binding ApproveButtonText}" CommandParameter="Approve" Grid.Row="0" Grid.Column="1"/>
+                    </Grid>
+                </Frame>
+            </Grid>
+        </RefreshView>
+    </ContentPage.Content>
+</ContentPage>

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Admin/AdminCoachApprovalProfilePage.xaml.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Admin/AdminCoachApprovalProfilePage.xaml.cs
@@ -1,0 +1,27 @@
+﻿using BuiltDifferentMobileApp.ViewModels.Admin;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace BuiltDifferentMobileApp.Views.Admin {
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    [QueryProperty(nameof(CoachId), nameof(CoachId))]
+    public partial class AdminCoachApprovalProfilePage : ContentPage {
+
+        public int CoachId { get; set; }
+
+        public AdminCoachApprovalProfilePage() {
+            InitializeComponent();
+        }
+
+        protected override async void OnAppearing() {
+            base.OnAppearing();
+            BindingContext = new AdminCoachApprovalProfilePageViewModel(CoachId);
+        }
+    }
+}


### PR DESCRIPTION
JIRA: [BUILT-23](https://champlainsaintlambert.atlassian.net/browse/BUILT-23?atlOrigin=eyJpIjoiMjg1MDgxOTNkNDYyNDU1YmJiMjZiOWM4NTAyOWY2NjciLCJwIjoiaiJ9)

## Context
This story adds a flyout page for admins to be able to view pending coach applications and review them. Currently only the display of pending coaches is supported (design WIP) and viewing their profile is supported however you cannot actually accept or deny them (design also WIP).

## Changes
- Added pending coaches list page
- Added pending coach's profile page

## Relevant screenshots
### Pending coaches list
![image](https://user-images.githubusercontent.com/55009009/149262879-a1299ead-7480-4ee9-85fb-fb8921d8fc75.png)
### Pending coach's profile page
![image](https://user-images.githubusercontent.com/55009009/149262901-94c43b7e-4418-4c33-b3ca-117c9816e4b0.png)
### Placeholder functional Accept/Deny buttons
![image](https://user-images.githubusercontent.com/55009009/149262955-893335d7-2bfd-4c36-aa9d-5524eda1bd83.png)
![image](https://user-images.githubusercontent.com/55009009/149262967-18e5d49f-d0e7-468c-b4ec-fb8ab85d39de.png)


