### PR TITLE
feat(BUILT-63): Coach Apply For Approval

### DIFF
--- a/BuiltDifferent.UITest/BuiltDifferent.UITest.csproj
+++ b/BuiltDifferent.UITest/BuiltDifferent.UITest.csproj
@@ -39,12 +39,10 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-
     <Compile Include="ClientCriteriaFormTests.cs" />
-
+    <Compile Include="CoachApplyForApprovalTests.cs" />
     <Compile Include="ForgotPasswordTests.cs" />
     <Compile Include="CreateAccountTests.cs" />
-
     <Compile Include="MealTests.cs" />
     <Compile Include="AppInitializer.cs" />
     <Compile Include="ProfileTests.cs" />

--- a/BuiltDifferent.UITest/CoachApplyForApprovalTests.cs
+++ b/BuiltDifferent.UITest/CoachApplyForApprovalTests.cs
@@ -1,0 +1,117 @@
+﻿using BuiltDifferentMobileApp.ViewModels.Coach;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xamarin.UITest;
+
+namespace BuiltDifferent.UITest {
+    [TestFixture(Platform.Android)]
+    public class CoachApplyForApprovalTests {
+
+        IApp app;
+        Platform platform;
+
+        public const string PENDING_COACH_EMAIL = "coach5";
+        public const string PENDING_COACH_PASSWORD = "coach5";
+
+        public CoachApplyForApprovalTests(Platform platform) {
+            this.platform = platform;
+        }
+
+        private string CheckErrorText() {
+            app.WaitForElement(e => e.Marked("ErrorText"));
+            return app.Query(label => label.Marked("ErrorText"))[0].Text;
+        }
+
+        [OneTimeSetUp]
+        public void OneTimeSetup() {
+            app = AppInitializer.StartApp(platform);
+
+            app.WaitForElement(e => e.Marked("Login"));
+
+            app.WaitForElement(e => e.Marked("Email"));
+            app.EnterText(e => e.Marked("Email"), PENDING_COACH_EMAIL);
+
+            app.WaitForElement(e => e.Marked("Password"));
+            app.EnterText(e => e.Marked("Password"), PENDING_COACH_PASSWORD);
+
+            app.DismissKeyboard();
+
+            app.Tap(e => e.Marked("Login"));
+
+            app.WaitForElement(e => e.Marked("Submit"));
+        }
+
+        [Test, Order(1)]
+        public void Test_Missing_Inputs_Error() {
+            if(platform == Platform.Android) {
+                app.Tap(e => e.Marked("Submit"));
+
+                string error = CheckErrorText();
+
+                Assert.AreEqual(error, NewCoachPageViewModel.MissingInputs);
+            } else {
+                return;
+            }
+        }
+
+        [Test, Order(2)]
+        public void Test_Gender_Unspecified_Error() {
+            if(platform == Platform.Android) {
+                app.Tap(x => x.Marked("GenderPicker"));
+
+                app.Tap(x => x.Text("Other"));
+
+                app.EnterText(x => x.Marked("Description"), "COACH DESCRIPTION");
+
+                app.EnterText(x => x.Marked("CoachPricing"), "69.00");
+
+                app.DismissKeyboard();
+
+                app.Tap(x => x.Marked("Submit"));
+
+                string error = CheckErrorText();
+                Assert.AreEqual(error, NewCoachPageViewModel.OtherGenderUnspecified);
+
+            } else {
+                return;
+            }
+        }
+
+        [Test, Order(3)]
+        public void Test_Missing_Certification_Error() {
+            if(platform == Platform.Android) {
+                app.EnterText(x => x.Marked("CustomGender"), "Coach");
+
+                app.Tap(x => x.Marked("Submit"));
+
+                string error = CheckErrorText();
+                Assert.AreEqual(error, NewCoachPageViewModel.MissingCertification);
+            } else {
+                return;
+            }
+        }
+
+        // MUST MANUALLY SELECT CERTIFICATION FOR THIS TEST
+        [Test, Order(4)]
+        public void Test_Successful_Application() {
+            if(platform == Platform.Android) {
+                app.Tap(x => x.Marked("FilePicker"));
+
+                app.WaitForElement(x => x.Marked("Submit"));
+                app.Tap(x => x.Marked("Submit"));
+
+                app.WaitForElement(e => e.Marked("CheckSubmissionStatus"));
+                string buttonText = app.Query(label => label.Marked("CheckSubmissionStatus"))[0].Text;
+
+                Assert.IsNotEmpty(buttonText);
+            } else {
+                return;
+            }
+        }
+
+    }
+}

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/AppShell.xaml
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/AppShell.xaml
@@ -93,10 +93,14 @@
         COACH PAGES
     -->
 
-    <FlyoutItem Title="Clients" IsVisible="{Binding IsCoach}">
+    <FlyoutItem Title="Clients" IsVisible="{Binding IsVerifiedCoach}">
         <ShellContent Route="CoachDashboardPage" ContentTemplate="{DataTemplate coachpages:CoachDashboardPage}" />
     </FlyoutItem>
 
+    <FlyoutItem Title="Apply for approval" IsVisible="{Binding IsUnverifiedCoach}">
+        <ShellContent Route="NewCoachPage" ContentTemplate="{DataTemplate coachpages:NewCoachPage}" />
+    </FlyoutItem>
+    
     <!--
         CLIENT PAGES
     -->

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/AppShell.xaml.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/AppShell.xaml.cs
@@ -27,6 +27,7 @@ namespace BuiltDifferentMobileApp {
             Routing.RegisterRoute(nameof(CoachWorkoutPage), typeof(CoachWorkoutPage));
             Routing.RegisterRoute(nameof(CoachMenuPage), typeof(CoachMenuPage));
             Routing.RegisterRoute(nameof(CoachDashboardPage), typeof(CoachDashboardPage));
+            Routing.RegisterRoute(nameof(NewCoachPage), typeof(NewCoachPage));
 
             // Client pages
             Routing.RegisterRoute(nameof(ClientMenuPage), typeof(ClientMenuPage));

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/BuiltDifferentMobileApp.csproj
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/BuiltDifferentMobileApp.csproj
@@ -68,6 +68,9 @@
     <EmbeddedResource Update="Views\Coach\EditWorkoutPage.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
+    <EmbeddedResource Update="Views\Coach\NewCoachPage.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
     <EmbeddedResource Update="Views\ForgotPassword\ForgotPasswordPage.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Models/CoachApprovalStatus.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Models/CoachApprovalStatus.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BuiltDifferentMobileApp.Models {
+    public class CoachApprovalStatus {
+        public string approvalStatus { get; set; }
+
+        public const string APPROVED = "APPROVED";
+        public const string PENDING = "PENDING";
+        public const string DENIED = "DENIED";
+    }
+}

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Services/AccountServices/AccountService.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Services/AccountServices/AccountService.cs
@@ -45,7 +45,7 @@ namespace BuiltDifferentMobileApp.Services.AccountServices {
                     else if(result.ContainsKey("isVerified")) {
                         CurrentUser = JsonConvert.DeserializeObject<Coach>(serializedUser);
                         CurrentUserRole = AccountConstants.Coach;
-                        AppShellViewModel.UpdateUserRole(AccountConstants.Coach);
+                        AppShellViewModel.UpdateUserRole(AccountConstants.Coach, ((Coach)CurrentUser).isVerified);
                     }
                     else {
                         return false;

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Services/Converters/BoolToInvertedBoolConverter.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Services/Converters/BoolToInvertedBoolConverter.cs
@@ -11,7 +11,7 @@ namespace BuiltDifferentMobileApp.Services.Converters {
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) {
-            return !(bool)value;
+            return (bool)value;
         }
     }
 }

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Services/NetworkServices/APIConstants.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Services/NetworkServices/APIConstants.cs
@@ -132,5 +132,9 @@ namespace BuiltDifferentMobileApp.Services.NetworkServices
         }
 
 
+        public static string UploadCertificationUri(int coachId) {
+            return $"{BaseAddress}/certification/upload/{coachId}";
+        }
+
     }
 }

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Services/NetworkServices/APIConstants.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Services/NetworkServices/APIConstants.cs
@@ -132,8 +132,16 @@ namespace BuiltDifferentMobileApp.Services.NetworkServices
         }
 
 
-        public static string UploadCertificationUri(int coachId) {
-            return $"{BaseAddress}/certification/upload/{coachId}";
+        public static string UploadCertificationUri() {
+            return $"{BaseAddress}/certification/upload";
+        }
+
+        public static string GetCoachCertificationUri(int coachId) {
+            return $"{BaseAddress}/certification/{coachId}";
+        }
+
+        public static string GetCoachApprovalStatusUri(int coachId) {
+            return $"{BaseAddress}/certification/{coachId}/status";
         }
 
     }

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Services/NetworkServices/INetworkService.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Services/NetworkServices/INetworkService.cs
@@ -13,10 +13,10 @@ namespace BuiltDifferentMobileApp.Services.NetworkServices {
         Task<TResult> GetAsync<TResult>(string uri);
         Task<bool> DeleteAsync(string uri);
         Task<TResult> PutAsync<TResult>(string uri, object data);
-        Task<TResult> PostAsync<TResult>(string uri, object data);
+        Task<TResult> PostAsync<TResult>(string uri, object data, bool IsEncoded = false);
         Task<HttpStatusCode> LoginAsync(string uri, object user);
         Task<HttpStatusCode> RegisterAsync(string uri, object user);
         void RemoveJWTToken();
-        Task<HttpStatusCode> PostAsyncHttpResponseMessage(string uri, object data);
+        Task<HttpStatusCode> PostAsyncHttpResponseMessage(string uri, object data, bool IsEncoded = false);
     }
 }

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Services/NetworkServices/INetworkService.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Services/NetworkServices/INetworkService.cs
@@ -18,5 +18,6 @@ namespace BuiltDifferentMobileApp.Services.NetworkServices {
         Task<HttpStatusCode> RegisterAsync(string uri, object user);
         void RemoveJWTToken();
         Task<HttpStatusCode> PostAsyncHttpResponseMessage(string uri, object data, bool IsEncoded = false);
+        Task<HttpStatusCode> PutAsyncHttpResponseMessage(string uri, object obj);
     }
 }

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Services/NetworkServices/INetworkService.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Services/NetworkServices/INetworkService.cs
@@ -19,5 +19,6 @@ namespace BuiltDifferentMobileApp.Services.NetworkServices {
         void RemoveJWTToken();
         Task<HttpStatusCode> PostAsyncHttpResponseMessage(string uri, object data, bool IsEncoded = false);
         Task<HttpStatusCode> PutAsyncHttpResponseMessage(string uri, object obj);
+        Task UpdateCurrentUser();
     }
 }

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Services/NetworkServices/NetworkService.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Services/NetworkServices/NetworkService.cs
@@ -153,6 +153,14 @@ namespace BuiltDifferentMobileApp.Services.NetworkServices
             }
         }
 
+        public async Task UpdateCurrentUser() {
+            try {
+                HttpResponseMessage profileResponse = await httpClient.GetAsync(APIConstants.GetLoginUri());
+
+                bool matchedAccountType = await accountService.SetCurrentUser(profileResponse);
+            } catch(Exception) { }
+        }
+
         public async Task<HttpStatusCode> RegisterAsync(string uri, object user) {
             try {
                 var json = JsonConvert.SerializeObject(user);

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Services/NetworkServices/NetworkService.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Services/NetworkServices/NetworkService.cs
@@ -195,5 +195,18 @@ namespace BuiltDifferentMobileApp.Services.NetworkServices
             }
         }
 
+        public async Task<HttpStatusCode> PutAsyncHttpResponseMessage(string uri, object obj) {
+            try {
+                var json = JsonConvert.SerializeObject(obj);
+                HttpContent content = new StringContent(json, Encoding.UTF8, "application/json");
+
+                var response = await httpClient.PutAsync(uri, content);
+
+                return response.StatusCode;
+            } catch(OperationCanceledException) {
+                return HttpStatusCode.RequestTimeout;
+            }
+        }
+
     }
 }

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Services/NetworkServices/NetworkService.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Services/NetworkServices/NetworkService.cs
@@ -78,14 +78,20 @@ namespace BuiltDifferentMobileApp.Services.NetworkServices
         }
 
 
-        public async Task<TResult> PostAsync<TResult>(string uri, object data)
+        public async Task<TResult> PostAsync<TResult>(string uri, object data, bool MultiPartFormData = false)
         {
             try
             {
-                var json = JsonConvert.SerializeObject(data);
-                var jsonString = new StringContent(json, Encoding.UTF8, "application/json");
+                HttpResponseMessage response = null;
 
-                HttpResponseMessage response = await httpClient.PostAsync(uri, jsonString);
+                if(!MultiPartFormData) {
+                    var json = JsonConvert.SerializeObject(data);
+                    var jsonString = new StringContent(json, Encoding.UTF8, "application/json");
+
+                    response = await httpClient.PostAsync(uri, jsonString);
+                } else {    
+                    response = await httpClient.PostAsync(uri, (MultipartFormDataContent)data);
+                }
 
                 if (response.IsSuccessStatusCode)
                 {
@@ -166,14 +172,20 @@ namespace BuiltDifferentMobileApp.Services.NetworkServices
         }
 
 
-        public async Task<HttpStatusCode> PostAsyncHttpResponseMessage(string uri, object data)
+        public async Task<HttpStatusCode> PostAsyncHttpResponseMessage(string uri, object data, bool MultiPartFormData = false)
         {
             try
             {
-                var json = JsonConvert.SerializeObject(data);
-                var jsonString = new StringContent(json, Encoding.UTF8, "application/json");
+                HttpResponseMessage response = null;
 
-                HttpResponseMessage response = await httpClient.PostAsync(uri, jsonString);
+                if(!MultiPartFormData) {
+                    var json = JsonConvert.SerializeObject(data);
+                    var jsonString = new StringContent(json, Encoding.UTF8, "application/json");
+
+                    response = await httpClient.PostAsync(uri, jsonString);
+                } else {
+                    response = await httpClient.PostAsync(uri, (MultipartFormDataContent)data);
+                }
 
                 return response.StatusCode;
             }

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/AppShellViewModel.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/AppShellViewModel.cs
@@ -12,10 +12,16 @@ namespace BuiltDifferentMobileApp.ViewModels {
             set => SetProperty(ref isAdmin, value);
         }
 
-        private bool isCoach;
-        public bool IsCoach {
-            get => isCoach;
-            set => SetProperty(ref isCoach, value);
+        private bool isVerifiedCoach;
+        public bool IsVerifiedCoach {
+            get => isVerifiedCoach;
+            set => SetProperty(ref isVerifiedCoach, value);
+        }
+
+        private bool isUnverifiedCoach;
+        public bool IsUnverifiedCoach {
+            get => isUnverifiedCoach;
+            set => SetProperty(ref isUnverifiedCoach, value);
         }
 
         private bool isClient;
@@ -28,20 +34,29 @@ namespace BuiltDifferentMobileApp.ViewModels {
             RemoveAllUserRoles();
         }
 
-        public void UpdateUserRole(string role) {
+        public void UpdateUserRole(string role, bool verified = false) {
             if(role == AccountConstants.Coach) {
                 IsClient = false;
-                IsCoach = true;
                 IsAdmin = false;
+
+                if(verified) {
+                    IsUnverifiedCoach = false;
+                    IsVerifiedCoach = true;
+                } else {
+                    IsUnverifiedCoach = true;
+                    IsVerifiedCoach = false;
+                }
             }
             else if(role == AccountConstants.Client) {
                 IsClient = true;
-                IsCoach = false;
+                IsUnverifiedCoach = false;
+                IsVerifiedCoach = false;
                 IsAdmin = false;
             }
             else if(role == AccountConstants.Admin) {
                 IsClient = false;
-                IsCoach = false;
+                IsUnverifiedCoach = false;
+                IsVerifiedCoach = false;
                 IsAdmin = true;
             }
             else {
@@ -51,7 +66,8 @@ namespace BuiltDifferentMobileApp.ViewModels {
 
         public void RemoveAllUserRoles() {
             IsClient = false;
-            IsCoach = false;
+            IsUnverifiedCoach = false;
+            IsVerifiedCoach = false;
             IsAdmin = false;
         }
     }

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Coach/NewCoachPageViewModel.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Coach/NewCoachPageViewModel.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Xamarin.CommunityToolkit.ObjectModel;
+
+namespace BuiltDifferentMobileApp.ViewModels.Coach {
+    public class NewCoachPageViewModel : ViewModelBase {
+
+        public List<string> GenderPickerList { get; set; }
+
+        public bool OtherGenderInputVisible { get; set; }
+        public string OtherGender { get; set; }
+
+        private string selectedGender;
+        public string SelectedGender {
+            get => selectedGender;
+            set {
+                selectedGender = value;
+                OtherGenderInputVisible = selectedGender == "Other";
+                OnPropertyChanged("OtherGenderInputVisible");
+                OnPropertyChanged();
+            }
+        }
+
+        public string Description { get; set; }
+        public string Pricing { get; set; }
+        public bool OfferWorkouts { get; set; }
+        public bool OfferMeals { get; set; }
+        public string FileName { get; set; }
+
+        public AsyncCommand SelectCertificationFileCommand { get; set; }
+        public AsyncCommand SubmitFormCommand { get; set; }
+
+        public NewCoachPageViewModel() {
+            Title = "Complete Account Setup";
+            OtherGender = "";
+            OtherGenderInputVisible = false;
+            Description = "";
+            Pricing = "";
+            OfferWorkouts = false;
+            OfferMeals = false;
+            FileName = "";
+
+            GenderPickerList = new List<string>() {
+                "Male", "Female", "Other"
+            };
+
+            SelectCertificationFileCommand = new AsyncCommand(SelectCertificationFile);
+            SubmitFormCommand = new AsyncCommand(SubmitForm);
+        }
+
+        private async Task SubmitForm() {
+            
+        }
+
+        private async Task SelectCertificationFile() {
+            
+        }
+    }
+}

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Coach/NewCoachPageViewModel.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Coach/NewCoachPageViewModel.cs
@@ -63,15 +63,36 @@ namespace BuiltDifferentMobileApp.ViewModels.Coach {
         }
 
         private async Task SubmitForm() {
+            if(string.IsNullOrWhiteSpace(Description) || string.IsNullOrWhiteSpace(Pricing)) {
+                return;
+            }
+
+            if(!GenderPickerList.Contains(SelectedGender)) {
+                return;
+            }
+
             var multipartFormContent = await GetMultiPartFormContent();
+
             if(multipartFormContent == null) {
                 return;
             }
 
-            var response = await networkService.PostAsyncHttpResponseMessage(APIConstants.UploadCertificationUri(accountService.CurrentUser.id), multipartFormContent, true);
+            var coachProfile = new Dictionary<string, string>() {
+                { "gender", SelectedGender == "Other" ? OtherGender : SelectedGender },
+                { "description", Description },
+                { "pricing", Pricing },
+                { "offersWorkout", OfferWorkouts.ToString() },
+                { "offersMeal", OfferMeals.ToString() },
+            };
 
-            if(((int)response >= 200) && ((int)response <= 299)) {
+            var uploadCertification = (int)await networkService.PostAsyncHttpResponseMessage(APIConstants.UploadCertificationUri(accountService.CurrentUser.id), multipartFormContent, true);
+            var uploadProfile = (int)await networkService.PutAsyncHttpResponseMessage(APIConstants.GetCoachByIdUri(accountService.CurrentUser.id), coachProfile);
+
+            if(uploadCertification >= 200 && uploadCertification <= 299 && uploadProfile >= 200 && uploadProfile <= 299) {
                 await Application.Current.MainPage.DisplayAlert("", "good", "OK");
+            }
+            else {
+
             }
         }
 

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Coach/NewCoachPageViewModel.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Coach/NewCoachPageViewModel.cs
@@ -1,8 +1,15 @@
-﻿using System;
+﻿using BuiltDifferentMobileApp.Services.AccountServices;
+using BuiltDifferentMobileApp.Services.NetworkServices;
+using System;
 using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
 using Xamarin.CommunityToolkit.ObjectModel;
+using Xamarin.Essentials;
+using Xamarin.Forms;
 
 namespace BuiltDifferentMobileApp.ViewModels.Coach {
     public class NewCoachPageViewModel : ViewModelBase {
@@ -29,6 +36,10 @@ namespace BuiltDifferentMobileApp.ViewModels.Coach {
         public bool OfferMeals { get; set; }
         public string FileName { get; set; }
 
+        private INetworkService<HttpResponseMessage> networkService = NetworkService<HttpResponseMessage>.Instance;
+        private FileResult Certification { get; set; }
+        private IAccountService accountService = AccountService.Instance;
+
         public AsyncCommand SelectCertificationFileCommand { get; set; }
         public AsyncCommand SubmitFormCommand { get; set; }
 
@@ -41,6 +52,7 @@ namespace BuiltDifferentMobileApp.ViewModels.Coach {
             OfferWorkouts = false;
             OfferMeals = false;
             FileName = "";
+            Certification = null;
 
             GenderPickerList = new List<string>() {
                 "Male", "Female", "Other"
@@ -51,11 +63,68 @@ namespace BuiltDifferentMobileApp.ViewModels.Coach {
         }
 
         private async Task SubmitForm() {
-            
+            var multipartFormContent = await GetMultiPartFormContent();
+            if(multipartFormContent == null) {
+                return;
+            }
+
+            var response = await networkService.PostAsyncHttpResponseMessage(APIConstants.UploadCertificationUri(accountService.CurrentUser.id), multipartFormContent, true);
+
+            if(((int)response >= 200) && ((int)response <= 299)) {
+                await Application.Current.MainPage.DisplayAlert("", "good", "OK");
+            }
         }
 
         private async Task SelectCertificationFile() {
-            
+            var customFileTypes = new FilePickerFileType(new Dictionary<DevicePlatform, IEnumerable<string>> {
+                { DevicePlatform.iOS, new[] { "application/pdf" } },
+                { DevicePlatform.Android, new[] { "application/pdf" } },
+            });
+
+            var options = new PickOptions {
+                PickerTitle = "Please select your certification (PDF)",
+                FileTypes = customFileTypes,
+            };
+
+            try {
+                var file = await FilePicker.PickAsync(options);
+
+                if(file != null && file.ContentType == "application/pdf") {
+                    FileName = $"File Name: {file.FileName}";
+
+                    // Processing inputted file to a stream is not done until the user submits in order to not create a stream closed error
+                    // This fixes the user having to select a file before hitting submit every time,
+                    // They can hit submit as many times as they want without having to select the file again
+                    Certification = file;
+                } 
+                else {
+                    FileName = "Invalid file type. Please select a PDF.";
+                }
+            }
+            // If the user doesn't select a file
+            catch(Exception) {
+                FileName = "";
+            }
+
+            OnPropertyChanged("FileName");
         }
+
+        private async Task<MultipartFormDataContent> GetMultiPartFormContent() {
+            try {
+                MultipartFormDataContent formContent = new MultipartFormDataContent();
+
+                // Read file contents & set MIME appopriately, application/pdf in this case
+                StreamContent fileContent = new StreamContent(await Certification.OpenReadAsync());
+                fileContent.Headers.ContentType = new MediaTypeHeaderValue(Certification.ContentType);
+
+                // Add it to the form content as "certification" and give the file a random GUID name to preserve privacy
+                formContent.Add(fileContent, "certification", Guid.NewGuid().ToString());
+
+                return formContent;
+            } catch {
+                return null;
+            }
+        }
+
     }
 }

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Login/LoginPageViewModel.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Login/LoginPageViewModel.cs
@@ -77,7 +77,12 @@ namespace BuiltDifferentMobileApp.ViewModels.Login {
                     await Shell.Current.GoToAsync($"//{nameof(AdminMenuPage)}");
                 }
                 else if(accountService.CurrentUserRole == AccountConstants.Coach) {
-                    await Shell.Current.GoToAsync($"//{nameof(CoachDashboardPage)}");
+                    if(((Models.Coach)accountService.CurrentUser).isVerified) {
+                        await Shell.Current.GoToAsync($"//{nameof(CoachDashboardPage)}");
+                    }
+                    else {
+                        await Shell.Current.GoToAsync($"//{nameof(NewCoachPage)}");
+                    }
                 }
                 else if(accountService.CurrentUserRole == AccountConstants.Client) {
                     await Shell.Current.GoToAsync($"//{nameof(ClientMenuPage)}");

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/NewCoachPage.xaml
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/NewCoachPage.xaml
@@ -24,39 +24,53 @@
                         <StackLayout>
                             <Label Text="Gender" FontAttributes="Bold" />
                             <StackLayout Orientation="Horizontal">
-                                <Picker ItemsSource="{Binding GenderPickerList}" SelectedItem="{Binding SelectedGender, Mode=TwoWay}" HorizontalOptions="Start" Title="Please select a gender" IsEnabled="{Binding IsBusy, Converter={StaticResource boolToInvertedBoolConverter}}" />
-                                <Entry Text="{Binding OtherGender}" MaxLength="32" Placeholder="Please specify." IsVisible="{Binding OtherGenderInputVisible}" HorizontalOptions="Start" IsEnabled="{Binding IsBusy, Converter={StaticResource boolToInvertedBoolConverter}}" />
+                                <Picker ItemsSource="{Binding GenderPickerList}" SelectedItem="{Binding SelectedGender, Mode=TwoWay}" HorizontalOptions="Start" Title="Please select a gender"
+                                        IsEnabled="{Binding IsBusy, Converter={StaticResource boolToInvertedBoolConverter}}" AutomationId="GenderPicker" />
+                                <Entry Text="{Binding OtherGender}" MaxLength="32" Placeholder="Please specify." IsVisible="{Binding OtherGenderInputVisible}"
+                                       HorizontalOptions="Start" IsEnabled="{Binding IsBusy, Converter={StaticResource boolToInvertedBoolConverter}}"
+                                       AutomationId="CustomGender"/>
                             </StackLayout>
                         </StackLayout>
 
                         <StackLayout>
                             <Label Text="How would you describe yourself to clients?" FontAttributes="Bold" />
-                            <Entry Text="{Binding Description}" MaxLength="250" Placeholder="I am a fun coach, always aspiring to..." IsEnabled="{Binding IsBusy, Converter={StaticResource boolToInvertedBoolConverter}}" />
+                            <Entry Text="{Binding Description}" MaxLength="250" Placeholder="I am a fun coach, always aspiring to..."
+                                   IsEnabled="{Binding IsBusy, Converter={StaticResource boolToInvertedBoolConverter}}"
+                                   AutomationId="Description"/>
                         </StackLayout>
 
                         <StackLayout>
                             <Label Text="Pricing" FontAttributes="Bold"/>
-                            <Entry Text="{Binding Pricing}" Keyboard="Numeric" Placeholder="29.99" IsEnabled="{Binding IsBusy, Converter={StaticResource boolToInvertedBoolConverter}}" />
+                            <Entry Text="{Binding Pricing}" Keyboard="Numeric" Placeholder="29.99" IsEnabled="{Binding IsBusy, Converter={StaticResource boolToInvertedBoolConverter}}"
+                                   AutomationId="CoachPricing" />
                         </StackLayout>
 
                         <StackLayout>
                             <Label Text="What do you want to provide coaching for?" FontAttributes="Bold"/>
                             <StackLayout Orientation="Horizontal">
-                                <CheckBox VerticalOptions="Center" IsChecked="{Binding OfferWorkouts}" Color="{StaticResource RedSecondary}" IsEnabled="{Binding IsBusy, Converter={StaticResource boolToInvertedBoolConverter}}" />
+                                <CheckBox VerticalOptions="Center" IsChecked="{Binding OfferWorkouts}" Color="{StaticResource RedSecondary}"
+                                          IsEnabled="{Binding IsBusy, Converter={StaticResource boolToInvertedBoolConverter}}"
+                                          AutomationId="OfferWorkouts"/>
                                 <Label Text="Workouts" VerticalOptions="Center"/>
-                                <CheckBox VerticalOptions="Center" IsChecked="{Binding OfferMeals}" Color="{StaticResource RedSecondary}" IsEnabled="{Binding IsBusy, Converter={StaticResource boolToInvertedBoolConverter}}" />
+                                <CheckBox VerticalOptions="Center" IsChecked="{Binding OfferMeals}" Color="{StaticResource RedSecondary}"
+                                          IsEnabled="{Binding IsBusy, Converter={StaticResource boolToInvertedBoolConverter}}"
+                                          AutomationId="OfferMeals"/>
                                 <Label Text="Meals" VerticalOptions="Center" />
                             </StackLayout>
                         </StackLayout>
 
                         <StackLayout Orientation="Vertical">
-                            <Button Text="Upload Certification (PDF)" Command="{Binding SelectCertificationFileCommand}" IsEnabled="{Binding IsBusy, Converter={StaticResource boolToInvertedBoolConverter}}"/>
+                            <Button Text="Upload Certification (PDF)" Command="{Binding SelectCertificationFileCommand}"
+                                    IsEnabled="{Binding IsBusy, Converter={StaticResource boolToInvertedBoolConverter}}"
+                                    AutomationId="FilePicker"/>
                             <Label Text="{Binding FileName}" HorizontalOptions="Center"/>
                         </StackLayout>
 
-                        <Label Text="{Binding ErrorText}" HorizontalOptions="Center" TextColor="Red"/>
+                        <Label Text="{Binding ErrorText}" HorizontalOptions="Center" TextColor="Red" AutomationId="ErrorText"/>
                     </StackLayout>
-                    <Button Text="Confirm Account Information" VerticalOptions="EndAndExpand" CornerRadius="0" Command="{Binding SubmitFormCommand}" IsEnabled="{Binding IsBusy, Converter={StaticResource boolToInvertedBoolConverter}}"/>
+                    <Button Text="Confirm Account Information" VerticalOptions="EndAndExpand" CornerRadius="0" Command="{Binding SubmitFormCommand}"
+                            IsEnabled="{Binding IsBusy, Converter={StaticResource boolToInvertedBoolConverter}}"
+                            AutomationId="Submit"/>
                 </StackLayout>
 
                 <StackLayout Grid.Row="0" Grid.Column="0"
@@ -66,7 +80,9 @@
                         <StackLayout>
                             <Label Text="{Binding PendingApprovalTitle}" FontSize="Subtitle" TextColor="Black" HorizontalOptions="Center"/>
                             <Label Text="{Binding PendingApprovalBody}" TextColor="Gray" HorizontalOptions="Center" />
-                            <Button Text="Check Application Status" Command="{Binding CheckIfSubmissionApprovedCommand}" HorizontalOptions="Center" Margin="0,12,0,0"/>
+                            <Button Text="Check Application Status" Command="{Binding CheckIfSubmissionApprovedCommand}"
+                                    HorizontalOptions="Center" Margin="0,12,0,0"
+                                    AutomationId="CheckSubmissionStatus"/>
                         </StackLayout>
                     </Frame>
                 </StackLayout>

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/NewCoachPage.xaml
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/NewCoachPage.xaml
@@ -17,44 +17,60 @@
     </ContentPage.Resources>
 
     <ContentPage.Content>
-        <StackLayout BackgroundColor="{StaticResource PageBackground}">
-            <StackLayout Padding="20" Spacing="16" BackgroundColor="{StaticResource PageBackground}">
-                <StackLayout>
-                    <Label Text="Gender" FontAttributes="Bold" />
-                    <StackLayout Orientation="Horizontal">
-                        <Picker ItemsSource="{Binding GenderPickerList}" SelectedItem="{Binding SelectedGender, Mode=TwoWay}" HorizontalOptions="Start" Title="Please select a gender" IsEnabled="{Binding IsBusy, Converter={StaticResource boolToInvertedBoolConverter}}" />
-                        <Entry Text="{Binding OtherGender}" MaxLength="32" Placeholder="Please specify." IsVisible="{Binding OtherGenderInputVisible}" HorizontalOptions="Start" IsEnabled="{Binding IsBusy, Converter={StaticResource boolToInvertedBoolConverter}}" />
+        <RefreshView IsRefreshing="{Binding IsBusy}">
+            <Grid>
+                <StackLayout BackgroundColor="{StaticResource PageBackground}" Grid.Row="0" Grid.Column="0">
+                    <StackLayout Padding="20" Spacing="16" BackgroundColor="{StaticResource PageBackground}">
+                        <StackLayout>
+                            <Label Text="Gender" FontAttributes="Bold" />
+                            <StackLayout Orientation="Horizontal">
+                                <Picker ItemsSource="{Binding GenderPickerList}" SelectedItem="{Binding SelectedGender, Mode=TwoWay}" HorizontalOptions="Start" Title="Please select a gender" IsEnabled="{Binding IsBusy, Converter={StaticResource boolToInvertedBoolConverter}}" />
+                                <Entry Text="{Binding OtherGender}" MaxLength="32" Placeholder="Please specify." IsVisible="{Binding OtherGenderInputVisible}" HorizontalOptions="Start" IsEnabled="{Binding IsBusy, Converter={StaticResource boolToInvertedBoolConverter}}" />
+                            </StackLayout>
+                        </StackLayout>
+
+                        <StackLayout>
+                            <Label Text="How would you describe yourself to clients?" FontAttributes="Bold" />
+                            <Entry Text="{Binding Description}" MaxLength="250" Placeholder="I am a fun coach, always aspiring to..." IsEnabled="{Binding IsBusy, Converter={StaticResource boolToInvertedBoolConverter}}" />
+                        </StackLayout>
+
+                        <StackLayout>
+                            <Label Text="Pricing" FontAttributes="Bold"/>
+                            <Entry Text="{Binding Pricing}" Keyboard="Numeric" Placeholder="29.99" IsEnabled="{Binding IsBusy, Converter={StaticResource boolToInvertedBoolConverter}}" />
+                        </StackLayout>
+
+                        <StackLayout>
+                            <Label Text="What do you want to provide coaching for?" FontAttributes="Bold"/>
+                            <StackLayout Orientation="Horizontal">
+                                <CheckBox VerticalOptions="Center" IsChecked="{Binding OfferWorkouts}" Color="{StaticResource RedSecondary}" IsEnabled="{Binding IsBusy, Converter={StaticResource boolToInvertedBoolConverter}}" />
+                                <Label Text="Workouts" VerticalOptions="Center"/>
+                                <CheckBox VerticalOptions="Center" IsChecked="{Binding OfferMeals}" Color="{StaticResource RedSecondary}" IsEnabled="{Binding IsBusy, Converter={StaticResource boolToInvertedBoolConverter}}" />
+                                <Label Text="Meals" VerticalOptions="Center" />
+                            </StackLayout>
+                        </StackLayout>
+
+                        <StackLayout Orientation="Vertical">
+                            <Button Text="Upload Certification (PDF)" Command="{Binding SelectCertificationFileCommand}" IsEnabled="{Binding IsBusy, Converter={StaticResource boolToInvertedBoolConverter}}"/>
+                            <Label Text="{Binding FileName}" HorizontalOptions="Center"/>
+                        </StackLayout>
+
+                        <Label Text="{Binding ErrorText}" HorizontalOptions="Center" TextColor="Red"/>
                     </StackLayout>
+                    <Button Text="Confirm Account Information" VerticalOptions="EndAndExpand" CornerRadius="0" Command="{Binding SubmitFormCommand}" IsEnabled="{Binding IsBusy, Converter={StaticResource boolToInvertedBoolConverter}}"/>
                 </StackLayout>
 
-                <StackLayout>
-                    <Label Text="How would you describe yourself to clients?" FontAttributes="Bold" />
-                    <Entry Text="{Binding Description}" MaxLength="250" Placeholder="I am a fun coach, always aspiring to..." IsEnabled="{Binding IsBusy, Converter={StaticResource boolToInvertedBoolConverter}}" />
+                <StackLayout Grid.Row="0" Grid.Column="0"
+                             BackgroundColor="#50000000"
+                             IsVisible="{Binding HasSubmittedCertification}">
+                    <Frame BorderColor="{StaticResource DarkGrey}" Margin="12,12,12,100" CornerRadius="6" VerticalOptions="CenterAndExpand">
+                        <StackLayout>
+                            <Label Text="Your application is currently pending review" FontSize="Subtitle" TextColor="Black" HorizontalOptions="Center"/>
+                            <Label Text="Please wait until you have been approved or denied." TextColor="Gray" HorizontalOptions="Center" />
+                        </StackLayout>
+                    </Frame>
                 </StackLayout>
-
-                <StackLayout>
-                    <Label Text="Pricing" FontAttributes="Bold"/>
-                    <Entry Text="{Binding Pricing}" Keyboard="Numeric" Placeholder="29.99" IsEnabled="{Binding IsBusy, Converter={StaticResource boolToInvertedBoolConverter}}" />
-                </StackLayout>
-
-                <StackLayout>
-                    <Label Text="What do you want to provide coaching for?" FontAttributes="Bold"/>
-                    <StackLayout Orientation="Horizontal">
-                        <CheckBox VerticalOptions="Center" IsChecked="{Binding OffersWorkouts}" Color="{StaticResource RedSecondary}" IsEnabled="{Binding IsBusy, Converter={StaticResource boolToInvertedBoolConverter}}" />
-                        <Label Text="Workouts" VerticalOptions="Center"/>
-                        <CheckBox VerticalOptions="Center" IsChecked="{Binding OffersMeals}" Color="{StaticResource RedSecondary}" IsEnabled="{Binding IsBusy, Converter={StaticResource boolToInvertedBoolConverter}}" />
-                        <Label Text="Meals" VerticalOptions="Center" />
-                    </StackLayout>
-                </StackLayout>
-
-                <StackLayout Orientation="Vertical">
-                    <Button Text="Upload Certification (PDF)" Command="{Binding SelectCertificationFileCommand}" IsEnabled="{Binding IsBusy, Converter={StaticResource boolToInvertedBoolConverter}}"/>
-                    <Label Text="{Binding FileName}" HorizontalOptions="Center"/>
-                </StackLayout>
-
-                <Label Text="{Binding ErrorText}" HorizontalOptions="Center" TextColor="Red"/>
-            </StackLayout>
-            <Button Text="Confirm Account Information" VerticalOptions="EndAndExpand" CornerRadius="0" Command="{Binding SubmitFormCommand}" IsEnabled="{Binding IsBusy, Converter={StaticResource boolToInvertedBoolConverter}}"/>
-        </StackLayout>
+            
+            </Grid>
+        </RefreshView>
     </ContentPage.Content>
 </ContentPage>

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/NewCoachPage.xaml
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/NewCoachPage.xaml
@@ -1,0 +1,51 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:viewmodels="clr-namespace:BuiltDifferentMobileApp.ViewModels.Coach"
+             x:Class="BuiltDifferentMobileApp.Views.Coach.NewCoachPage"
+             Title="{Binding Title}">
+
+    <ContentPage.BindingContext>
+        <viewmodels:NewCoachPageViewModel />
+    </ContentPage.BindingContext>
+    
+    <ContentPage.Content>
+        <StackLayout BackgroundColor="{StaticResource PageBackground}">
+            <StackLayout Padding="20" Spacing="16" BackgroundColor="{StaticResource PageBackground}">
+                <StackLayout>
+                    <Label Text="Gender" FontAttributes="Bold" />
+                    <StackLayout Orientation="Horizontal">
+                        <Picker ItemsSource="{Binding GenderPickerList}" SelectedItem="{Binding SelectedGender, Mode=TwoWay}" HorizontalOptions="Start" Title="Please select a gender"/>
+                        <Entry Text="{Binding OtherGender}" MaxLength="32" Placeholder="Please specify." IsVisible="{Binding OtherGenderInputVisible}" HorizontalOptions="Start"/>
+                    </StackLayout>
+                </StackLayout>
+
+                <StackLayout>
+                    <Label Text="How would you describe yourself to clients?" FontAttributes="Bold" />
+                    <Entry Text="{Binding Description}" MaxLength="250" Placeholder="I am a fun coach, always aspiring to..."/>
+                </StackLayout>
+
+                <StackLayout>
+                    <Label Text="Pricing" FontAttributes="Bold"/>
+                    <Entry Text="{Binding Pricing}" Keyboard="Numeric" Placeholder="29.99"/>
+                </StackLayout>
+
+                <StackLayout>
+                    <Label Text="What do you want to provide coaching for?" FontAttributes="Bold"/>
+                    <StackLayout Orientation="Horizontal">
+                        <CheckBox VerticalOptions="Center" IsChecked="{Binding OffersWorkouts}" Color="{StaticResource RedSecondary}"/>
+                        <Label Text="Workouts" VerticalOptions="Center"/>
+                        <CheckBox VerticalOptions="Center" IsChecked="{Binding OffersMeals}" Color="{StaticResource RedSecondary}"/>
+                        <Label Text="Meals" VerticalOptions="Center" />
+                    </StackLayout>
+                </StackLayout>
+
+                <StackLayout Orientation="Vertical">
+                    <Button Text="Upload Certification (PDF)" Command="{Binding SelectCertificationFileCommand}"/>
+                    <Label Text="{Binding FileName}" HorizontalOptions="Center"/>
+                </StackLayout>
+            </StackLayout>
+            <Button Text="Confirm Account Information" VerticalOptions="EndAndExpand" CornerRadius="0" Command="{Binding SubmitFormCommand}"/>
+        </StackLayout>
+    </ContentPage.Content>
+</ContentPage>

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/NewCoachPage.xaml
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/NewCoachPage.xaml
@@ -64,8 +64,9 @@
                              IsVisible="{Binding HasSubmittedCertification}">
                     <Frame BorderColor="{StaticResource DarkGrey}" Margin="12,12,12,100" CornerRadius="6" VerticalOptions="CenterAndExpand">
                         <StackLayout>
-                            <Label Text="Your application is currently pending review" FontSize="Subtitle" TextColor="Black" HorizontalOptions="Center"/>
-                            <Label Text="Please wait until you have been approved or denied." TextColor="Gray" HorizontalOptions="Center" />
+                            <Label Text="{Binding PendingApprovalTitle}" FontSize="Subtitle" TextColor="Black" HorizontalOptions="Center"/>
+                            <Label Text="{Binding PendingApprovalBody}" TextColor="Gray" HorizontalOptions="Center" />
+                            <Button Text="Check Application Status" Command="{Binding CheckIfSubmissionApprovedCommand}" HorizontalOptions="Center" Margin="0,12,0,0"/>
                         </StackLayout>
                     </Frame>
                 </StackLayout>

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/NewCoachPage.xaml
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/NewCoachPage.xaml
@@ -2,50 +2,59 @@
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:viewmodels="clr-namespace:BuiltDifferentMobileApp.ViewModels.Coach"
+             xmlns:converters="clr-namespace:BuiltDifferentMobileApp.Services.Converters"
              x:Class="BuiltDifferentMobileApp.Views.Coach.NewCoachPage"
              Title="{Binding Title}">
 
     <ContentPage.BindingContext>
         <viewmodels:NewCoachPageViewModel />
     </ContentPage.BindingContext>
-    
+
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <converters:BoolToInvertedBoolConverter x:Key="boolToInvertedBoolConverter" />
+        </ResourceDictionary>
+    </ContentPage.Resources>
+
     <ContentPage.Content>
         <StackLayout BackgroundColor="{StaticResource PageBackground}">
             <StackLayout Padding="20" Spacing="16" BackgroundColor="{StaticResource PageBackground}">
                 <StackLayout>
                     <Label Text="Gender" FontAttributes="Bold" />
                     <StackLayout Orientation="Horizontal">
-                        <Picker ItemsSource="{Binding GenderPickerList}" SelectedItem="{Binding SelectedGender, Mode=TwoWay}" HorizontalOptions="Start" Title="Please select a gender"/>
-                        <Entry Text="{Binding OtherGender}" MaxLength="32" Placeholder="Please specify." IsVisible="{Binding OtherGenderInputVisible}" HorizontalOptions="Start"/>
+                        <Picker ItemsSource="{Binding GenderPickerList}" SelectedItem="{Binding SelectedGender, Mode=TwoWay}" HorizontalOptions="Start" Title="Please select a gender" IsEnabled="{Binding IsBusy, Converter={StaticResource boolToInvertedBoolConverter}}" />
+                        <Entry Text="{Binding OtherGender}" MaxLength="32" Placeholder="Please specify." IsVisible="{Binding OtherGenderInputVisible}" HorizontalOptions="Start" IsEnabled="{Binding IsBusy, Converter={StaticResource boolToInvertedBoolConverter}}" />
                     </StackLayout>
                 </StackLayout>
 
                 <StackLayout>
                     <Label Text="How would you describe yourself to clients?" FontAttributes="Bold" />
-                    <Entry Text="{Binding Description}" MaxLength="250" Placeholder="I am a fun coach, always aspiring to..."/>
+                    <Entry Text="{Binding Description}" MaxLength="250" Placeholder="I am a fun coach, always aspiring to..." IsEnabled="{Binding IsBusy, Converter={StaticResource boolToInvertedBoolConverter}}" />
                 </StackLayout>
 
                 <StackLayout>
                     <Label Text="Pricing" FontAttributes="Bold"/>
-                    <Entry Text="{Binding Pricing}" Keyboard="Numeric" Placeholder="29.99"/>
+                    <Entry Text="{Binding Pricing}" Keyboard="Numeric" Placeholder="29.99" IsEnabled="{Binding IsBusy, Converter={StaticResource boolToInvertedBoolConverter}}" />
                 </StackLayout>
 
                 <StackLayout>
                     <Label Text="What do you want to provide coaching for?" FontAttributes="Bold"/>
                     <StackLayout Orientation="Horizontal">
-                        <CheckBox VerticalOptions="Center" IsChecked="{Binding OffersWorkouts}" Color="{StaticResource RedSecondary}"/>
+                        <CheckBox VerticalOptions="Center" IsChecked="{Binding OffersWorkouts}" Color="{StaticResource RedSecondary}" IsEnabled="{Binding IsBusy, Converter={StaticResource boolToInvertedBoolConverter}}" />
                         <Label Text="Workouts" VerticalOptions="Center"/>
-                        <CheckBox VerticalOptions="Center" IsChecked="{Binding OffersMeals}" Color="{StaticResource RedSecondary}"/>
+                        <CheckBox VerticalOptions="Center" IsChecked="{Binding OffersMeals}" Color="{StaticResource RedSecondary}" IsEnabled="{Binding IsBusy, Converter={StaticResource boolToInvertedBoolConverter}}" />
                         <Label Text="Meals" VerticalOptions="Center" />
                     </StackLayout>
                 </StackLayout>
 
                 <StackLayout Orientation="Vertical">
-                    <Button Text="Upload Certification (PDF)" Command="{Binding SelectCertificationFileCommand}"/>
+                    <Button Text="Upload Certification (PDF)" Command="{Binding SelectCertificationFileCommand}" IsEnabled="{Binding IsBusy, Converter={StaticResource boolToInvertedBoolConverter}}"/>
                     <Label Text="{Binding FileName}" HorizontalOptions="Center"/>
                 </StackLayout>
+
+                <Label Text="{Binding ErrorText}" HorizontalOptions="Center" TextColor="Red"/>
             </StackLayout>
-            <Button Text="Confirm Account Information" VerticalOptions="EndAndExpand" CornerRadius="0" Command="{Binding SubmitFormCommand}"/>
+            <Button Text="Confirm Account Information" VerticalOptions="EndAndExpand" CornerRadius="0" Command="{Binding SubmitFormCommand}" IsEnabled="{Binding IsBusy, Converter={StaticResource boolToInvertedBoolConverter}}"/>
         </StackLayout>
     </ContentPage.Content>
 </ContentPage>

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/NewCoachPage.xaml.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/NewCoachPage.xaml.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace BuiltDifferentMobileApp.Views.Coach {
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class NewCoachPage : ContentPage {
+        public NewCoachPage() {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
JIRA: [BUILT-63](https://champlainsaintlambert.atlassian.net/browse/BUILT-63?atlOrigin=eyJpIjoiNGQwYmQwMGMzZWE5NDEzMjg4MjhkMWJhMDZiODc1OGIiLCJwIjoiaiJ9)

## Context
This story allows a coach to apply for approval of their account before they can offer their services. Once they submit their application, they will show up in the pending coach applications list for admins.

## Changes
- Split Coach page visibility Boolean into Verified and Unverified Coaches
- Added approval status model
- Added extra implementation into existing PostAsync for multipart/form-data
- Added more constants to APIConstants
- Added a PUT in NetworkService that returns HttpResponseStatus
- Added function to update AccountService's current user called `UpdateCurrentUser()` in NetworkService (can use it if you want @Chloedunwoody)

## Relevant screenshots (Optional)
### Application Page
![image](https://user-images.githubusercontent.com/55009009/150653955-5102cde6-ca75-4298-9a4e-d5b059e511c9.png)
### Filled Out Form
![image](https://user-images.githubusercontent.com/55009009/150653958-cd2fa056-7451-40e7-91b1-4624060763cf.png)
### Note: `Check Application Status` button is possibly temporary if we want to delve into Sockets for the API and APP.
![image](https://user-images.githubusercontent.com/55009009/150653972-91c031e8-8142-4ba7-acb0-7b6d7d49a08f.png)
