### PR TITLE
Bug/BUILT-78 CoachId and ClientId were hardcoded in meal and workout add

### DIFF
--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp.Android/Resources/Resource.designer.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp.Android/Resources/Resource.designer.cs
@@ -14,7 +14,7 @@ namespace BuiltDifferentMobileApp.Droid
 {
 	
 	
-	[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "12.1.0.11")]
+	[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "1.0.0.0")]
 	public partial class Resource
 	{
 		

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/BuiltDifferentMobileApp.csproj
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/BuiltDifferentMobileApp.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
+    <UserSecretsId>16650aef-dcc0-4eab-ae33-9d1d20305c2f</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Coach/AddMealViewModel.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Coach/AddMealViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using BuiltDifferentMobileApp.Models;
+using BuiltDifferentMobileApp.Services.AccountServices;
 using BuiltDifferentMobileApp.Services.NetworkServices;
 using Newtonsoft.Json;
 using System;
@@ -13,6 +14,9 @@ namespace BuiltDifferentMobileApp.ViewModels.Coach
 {
     public class AddMealViewModel : ViewModelBase
     {
+        private int id;
+        private int coachId;
+        private int clientId;
         private string mealName;
         public string MealName { get => mealName; set => SetProperty(ref mealName, value); }
         private string mealType;
@@ -33,11 +37,13 @@ namespace BuiltDifferentMobileApp.ViewModels.Coach
         public string ImageLink { get => imageLink; set => SetProperty(ref imageLink, value); }
         public Xamarin.CommunityToolkit.ObjectModel.AsyncCommand SaveCommand { get; }
         private INetworkService<HttpResponseMessage> networkService = NetworkService<HttpResponseMessage>.Instance;
-
+        private IAccountService accountService = AccountService.Instance;
         public ObservableRangeCollection<string> Types { get; set; }
-        public AddMealViewModel()
+        public AddMealViewModel(int clientId)
         {
-
+            this.clientId = clientId;
+            var user = (Models.Coach)accountService.CurrentUser;
+            coachId = user.id;
             Title = "Add Meal";
             SaveCommand = new AsyncCommand(SaveMeal);
             Types = new ObservableRangeCollection<string>
@@ -64,7 +70,7 @@ namespace BuiltDifferentMobileApp.ViewModels.Coach
             //empty strings for receipe and image link
             //must have receipe and image link filled
 
-            var meal = new  MealDTO(1,1,MealName, MealType, Calories, Protein, Carbs, Fat, "recipe", "imagelink.com", Day, false);
+            var meal = new  MealDTO(clientId,coachId,MealName, MealType, Calories, Protein, Carbs, Fat, "recipe", "imagelink.com", Day, false);
             var test = JsonConvert.SerializeObject(meal);
             var result = await networkService.PostAsync<HttpResponseMessage>(APIConstants.PostMealUri(), meal);
             var httpCode = result.StatusCode;

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Coach/AddWorkoutViewModel.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Coach/AddWorkoutViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using BuiltDifferentMobileApp.Models;
+using BuiltDifferentMobileApp.Services.AccountServices;
 using BuiltDifferentMobileApp.Services.NetworkServices;
 using Newtonsoft.Json;
 using System;
@@ -42,14 +43,16 @@ namespace BuiltDifferentMobileApp.ViewModels.Coach
         public bool IsCompleted { get => isCompleted; set => SetProperty(ref isCompleted, value); }
         public string VideoLink { get => videoLink; set => SetProperty(ref videoLink, value); }
 
-
+        private IAccountService accountService = AccountService.Instance;
         public List<WorkoutType> Types { get; set; }
 
         private INetworkService<HttpResponseMessage> networkService = NetworkService<HttpResponseMessage>.Instance;
         public AsyncCommand SaveCommand { get; }
-        public AddWorkoutViewModel()
+        public AddWorkoutViewModel(int clientId)
         {
-            
+            this.clientId = clientId;
+            var user = (Models.Coach)accountService.CurrentUser;
+            coachId = user.id;
             SaveCommand = new AsyncCommand(SaveWorkout);
             Day = DateTime.Now.Date;
             Types = new List<WorkoutType>
@@ -75,7 +78,7 @@ namespace BuiltDifferentMobileApp.ViewModels.Coach
                 return;
             }
 
-            var workout = new Workout(1,1, WorkoutType.Name, WorkoutName, Convert.ToInt32(Sets), Convert.ToInt32(Reps), Convert.ToInt32(Duration), Convert.ToInt32(RestTime),Day,Description, isCompleted,VideoLink);
+            var workout = new Workout(coachId, clientId, WorkoutType.Name, WorkoutName, Convert.ToInt32(Sets), Convert.ToInt32(Reps), Convert.ToInt32(Duration), Convert.ToInt32(RestTime),Day,Description, isCompleted,VideoLink);
             var result = await networkService.PostAsync<HttpResponseMessage>(APIConstants.PostWorkoutUri(), workout);
             var httpCode = result.StatusCode;
 

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Coach/CoachMealViewModel.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Coach/CoachMealViewModel.cs
@@ -60,7 +60,7 @@ namespace BuiltDifferentMobileApp.ViewModels.Coach
 
         private async Task AddMeal()
         {
-            var route = $"{nameof(AddMealPage)}";
+            var route = $"{nameof(AddMealPage)}?clientId={clientId}";
            
             await Shell.Current.GoToAsync(route);
         }

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Coach/CoachWorkoutViewModel.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Coach/CoachWorkoutViewModel.cs
@@ -58,7 +58,7 @@ namespace BuiltDifferentMobileApp.ViewModels.Coach
         }
         private async Task AddWorkout()
         {
-            var route = $"{nameof(AddWorkoutPage)}";
+            var route = $"{nameof(AddWorkoutPage)}?clientId={clientId}";
             await Shell.Current.GoToAsync(route);
         }
 

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/AddMealPage.xaml.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/AddMealPage.xaml.cs
@@ -12,12 +12,20 @@ using Xamarin.Forms.Xaml;
 namespace BuiltDifferentMobileApp.Views.Coach
 {
     [XamlCompilation(XamlCompilationOptions.Compile)]
+    [QueryProperty(nameof(clientId), nameof(clientId))]
     public partial class AddMealPage : ContentPage
     {
+        public int clientId { get; set; }
         public AddMealPage()
         {
             InitializeComponent();
-            BindingContext = new AddMealViewModel();
+
+        }
+
+        protected override async void OnAppearing()
+        {
+            base.OnAppearing();
+            BindingContext = new AddMealViewModel(clientId);
         }
     }
 }

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/AddWorkoutPage.xaml.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/AddWorkoutPage.xaml.cs
@@ -12,12 +12,20 @@ using Xamarin.Forms.Xaml;
 namespace BuiltDifferentMobileApp.Views.Coach
 {
     [XamlCompilation(XamlCompilationOptions.Compile)]
+    [QueryProperty(nameof(clientId), nameof(clientId))]
     public partial class AddWorkoutPage : ContentPage
     {
+        public int clientId { get; set; }
         public AddWorkoutPage()
         {
             InitializeComponent();
-            BindingContext = new AddWorkoutViewModel();
+
+        }
+
+        protected override async void OnAppearing()
+        {
+            base.OnAppearing();
+            BindingContext = new AddWorkoutViewModel(clientId);
         }
     }
 }


### PR DESCRIPTION
JIRA: https://champlainsaintlambert.atlassian.net/jira/software/projects/BUILT/boards/21/backlog?selectedIssue=BUILT-78

## Context

Fixing a bug where all workouts and meals created would have its coachid and clientid set as 1
## Changes
the addMealPage and addWorkoutPage now receive the clientId as a parameter so it can be used by the viewmodel and the coachId is taken from the user instance

## Relevant screenshots (Optional)
