### PR TITLE
feat(BUILT-25): Admin suspend coaches

### DIFF
--- a/BuiltDifferent.UITest/AdminInteractWithCoachAccountsTests.cs
+++ b/BuiltDifferent.UITest/AdminInteractWithCoachAccountsTests.cs
@@ -77,5 +77,27 @@ namespace BuiltDifferent.UITest {
                 return;
             }
         }
+
+        [Test]
+        public void Set_Coach_Account_Status() {
+            if(platform == Platform.Android) {
+                GoToFlyoutPage("Verified Coaches");
+                app.Tap(e => e.Text("Coach Bob"));
+
+                app.WaitForElement(x => x.Marked("SetCoachAccountStatusButton"));
+
+                string initialButtonText = app.Query(x => x.Marked("SetCoachAccountStatusButton"))[0].Text;
+
+                app.Tap(x => x.Marked("SetCoachAccountStatusButton"));
+
+                string postButtonText = app.Query(x => x.Marked("SetCoachAccountStatusButton"))[0].Text;
+
+                Assert.AreNotEqual(initialButtonText, postButtonText);
+            }
+            //if IOS
+            else {
+                return;
+            }
+        }
     }
 }

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp.Android/BuiltDifferentMobileApp.Android.csproj
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp.Android/BuiltDifferentMobileApp.Android.csproj
@@ -34,6 +34,11 @@
     <AndroidLinkMode>None</AndroidLinkMode>
     <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
     <AndroidSupportedAbis>x86;x86_64</AndroidSupportedAbis>
+    <AotAssemblies>false</AotAssemblies>
+    <EnableLLVM>false</EnableLLVM>
+    <AndroidEnableProfiledAot>false</AndroidEnableProfiledAot>
+    <BundleAssemblies>false</BundleAssemblies>
+    <MandroidI18n />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp.Android/Resources/Resource.designer.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp.Android/Resources/Resource.designer.cs
@@ -14,7 +14,7 @@ namespace BuiltDifferentMobileApp.Droid
 {
 	
 	
-	[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "1.0.0.0")]
+	[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "12.1.0.11")]
 	public partial class Resource
 	{
 		

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Models/AccountStatus.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Models/AccountStatus.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BuiltDifferentMobileApp.Models {
+    public class AccountStatus {
+        public string accountStatus { get; set; }
+
+        public AccountStatus(string accountStatus) {
+            this.accountStatus = accountStatus;
+        }
+    }
+}

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Models/AccountStatusConstants.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Models/AccountStatusConstants.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BuiltDifferentMobileApp.Models {
+    public class AccountStatusConstants {
+
+        public const string Active = "ACTIVE";
+        public const string Suspended = "SUSPENDED";
+
+    }
+}

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Ressource/AppResource.Designer.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Ressource/AppResource.Designer.cs
@@ -19,7 +19,7 @@ namespace BuiltDifferentMobileApp.Ressource {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class AppResource {

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Services/Converters/BoolToSetAccountStatusButtonConverter.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Services/Converters/BoolToSetAccountStatusButtonConverter.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using Xamarin.Forms;
+
+namespace BuiltDifferentMobileApp.Services.Converters {
+    internal class BoolToSetAccountStatusButtonConverter : IValueConverter {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture) {
+            return (bool)value ? "Unsuspend user" : "Suspend user";
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) {
+            return (bool)value ? "Unsuspend user" : "Suspend user";
+        }
+    }
+}

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Services/NetworkServices/APIConstants.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Services/NetworkServices/APIConstants.cs
@@ -148,5 +148,9 @@ namespace BuiltDifferentMobileApp.Services.NetworkServices
             return $"{BaseAddress}/admin/applications/{coachId}";
         }
 
+        public static string GetUserAccountStatusUri(int userId) {
+            return $"{BaseAddress}/admin/user/{userId}/accountStatus";
+        }
+
     }
 }

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Admin/AdminApprovedCoachesPageViewModel.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Admin/AdminApprovedCoachesPageViewModel.cs
@@ -42,7 +42,10 @@ namespace BuiltDifferentMobileApp.ViewModels.Admin {
 
             var coaches = await networkService.GetAsync<List<Models.Coach>>(APIConstants.GetAllVerifiedCoaches());
 
-            if(coaches.Count > 0) {
+            if(coaches == null) {
+                Coaches = new ObservableRangeCollection<Models.Coach>();
+            }
+            else if(coaches.Count > 0) {
                 Coaches = new ObservableRangeCollection<Models.Coach>(coaches);
             } else {
                 Coaches = new ObservableRangeCollection<Models.Coach>();

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Admin/AdminCoachApprovalPageViewModel.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Admin/AdminCoachApprovalPageViewModel.cs
@@ -41,7 +41,10 @@ namespace BuiltDifferentMobileApp.ViewModels.Admin {
 
             var coaches = await networkService.GetAsync<List<Models.Coach>>(APIConstants.GetPendingCoachesUri());
 
-            if(coaches.Count > 0) {
+            if(coaches == null) {
+                Coaches = new ObservableRangeCollection<Models.Coach>();
+            }
+            else if(coaches.Count > 0) {
                 Coaches = new ObservableRangeCollection<Models.Coach>(coaches);
             } else {
                 Coaches = new ObservableRangeCollection<Models.Coach>();

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Client/ClientCoachSelectionViewModel.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Client/ClientCoachSelectionViewModel.cs
@@ -58,7 +58,7 @@ namespace BuiltDifferentMobileApp.ViewModels.Client
             }
             
             var result = await networkService.GetAsync<ObservableRangeCollection<Models.Coach>>(APIConstants.GetAllAvailableCoach(query));
-            if (result.Count == 0)
+            if (result == null || result.Count == 0)
             {
                 return;
             }

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Coach/CoachDashboardPageViewModel.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Coach/CoachDashboardPageViewModel.cs
@@ -65,7 +65,10 @@ namespace BuiltDifferentMobileApp.ViewModels.Coach {
 
             List<Models.Client> clients = await networkService.GetAsync<List<Models.Client>>(APIConstants.GetClientsForCoachId(coachId));
 
-            if(clients.Count != 0) {
+            if(clients == null) {
+                Clients = new ObservableRangeCollection<Models.Client>();
+            }
+            else if(clients.Count != 0) {
                 originalClients = clients;
                 Clients = new ObservableRangeCollection<Models.Client>(clients);
             } else {

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Coach/CoachMealViewModel.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Coach/CoachMealViewModel.cs
@@ -97,7 +97,7 @@ namespace BuiltDifferentMobileApp.ViewModels.Coach
         {
 
             var result = await networkService.GetAsync<ObservableRangeCollection<Meal>>(APIConstants.GetMealsByClientId(clientId));
-            if (result.Count == 0)
+            if (result == null || result.Count == 0)
             {
                 return;
             }

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Coach/CoachWorkoutViewModel.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Coach/CoachWorkoutViewModel.cs
@@ -48,7 +48,7 @@ namespace BuiltDifferentMobileApp.ViewModels.Coach
         public async Task GetWorkouts()
         {
             var result = await networkService.GetAsync<ObservableRangeCollection<WorkoutDTO>>(APIConstants.GetWorkoutsByClientId(clientId));
-            if (result.Count == 0)
+            if (result == null || result.Count == 0)
             {
                 return;
             }

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Coach/NewCoachPageViewModel.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Coach/NewCoachPageViewModel.cs
@@ -112,14 +112,16 @@ namespace BuiltDifferentMobileApp.ViewModels.Coach {
 
             var approval = await networkService.GetAsync<Models.CoachApprovalStatus>(APIConstants.GetCoachApprovalStatusUri(accountService.CurrentUser.id));
 
-            if(approval.approvalStatus == ApprovalConstants.APPROVED) {
+            if(approval == null) {
+                PendingApprovalTitle = ApprovalPendingTitle;
+                PendingApprovalBody = ApprovalPendingBody;
+            } else if(approval.approvalStatus == ApprovalConstants.APPROVED) {
                 PendingApprovalTitle = ApprovalPassedTitle;
                 PendingApprovalBody = ApprovalPassedBody;
                 await networkService.UpdateCurrentUser();
                 await Task.Delay(1000);
                 await Shell.Current.GoToAsync($"//{nameof(CoachDashboardPage)}");
-            }
-            else if(approval.approvalStatus == ApprovalConstants.DENIED) {
+            } else if(approval.approvalStatus == ApprovalConstants.DENIED) {
                 PendingApprovalTitle = ApprovalDeniedTitle;
                 PendingApprovalBody = ApprovalDeniedBody;
             } else {

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Login/LoginPageViewModel.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Login/LoginPageViewModel.cs
@@ -38,6 +38,7 @@ namespace BuiltDifferentMobileApp.ViewModels.Login {
         private string LoginAttempsExceededText = AppResource.LoginAttempsExceededText;
         private string UnknownErrorText = AppResource.UnknownErrorText;
         private string MissingInputs = AppResource.MissingInputs;
+        private const string AccountSuspendedText = "This account has been suspended.";
 
         private string errorText;
         public string ErrorText {
@@ -76,29 +77,24 @@ namespace BuiltDifferentMobileApp.ViewModels.Login {
 
                 if(accountService.CurrentUserRole == AccountConstants.Admin) {
                     await Shell.Current.GoToAsync($"//{nameof(AdminMenuPage)}");
-                }
-                else if(accountService.CurrentUserRole == AccountConstants.Coach) {
+                } else if(accountService.CurrentUserRole == AccountConstants.Coach) {
                     if(((Models.Coach)accountService.CurrentUser).isVerified) {
                         await Shell.Current.GoToAsync($"//{nameof(CoachDashboardPage)}");
-                    }
-                    else {
+                    } else {
                         await Shell.Current.GoToAsync($"//{nameof(NewCoachPage)}");
                     }
-                }
-                else if(accountService.CurrentUserRole == AccountConstants.Client) {
+                } else if(accountService.CurrentUserRole == AccountConstants.Client) {
                     await Shell.Current.GoToAsync($"//{nameof(ClientMenuPage)}");
                 }
-            }
-            else if((int)response == 404) {
+            } else if((int)response == 404) {
                 ErrorText = AccountNotFoundText;
-            }
-            else if(response == HttpStatusCode.Unauthorized){
+            } else if(response == HttpStatusCode.Unauthorized) {
                 ErrorText = IncorrectLoginText;
-            }
-            else if((int)response == 429) {
+            } else if(response == HttpStatusCode.Forbidden) {
+                ErrorText = AccountSuspendedText;
+            } else if((int)response == 429) {
                 ErrorText = LoginAttempsExceededText;
-            }
-            else {
+            } else {
                 ErrorText = UnknownErrorText;
             }
 

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Profile/MyProfilePageClientViewModel.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Profile/MyProfilePageClientViewModel.cs
@@ -88,6 +88,9 @@ namespace BuiltDifferentMobileApp.ViewModels.Profile {
         {
             Models.Client user = (Models.Client)accountService.CurrentUser;
             var userInfo = await networkService.GetAsync<Models.Client>(APIConstants.GetClientProfileUri(user.userId));
+
+            if(userInfo == null) return;
+
             accountService.CurrentUser = userInfo;
 
             Id = userInfo.id;

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Admin/AdminApprovedCoachProfilePage.xaml
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Admin/AdminApprovedCoachProfilePage.xaml
@@ -1,8 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:converters="clr-namespace:BuiltDifferentMobileApp.Services.Converters"
              x:Class="BuiltDifferentMobileApp.Views.Admin.AdminApprovedCoachProfilePage"
              Title="{Binding Title}">
+
+    <ContentPage.Resources>
+        <converters:BoolToSetAccountStatusButtonConverter x:Key="boolToSetAccountStatusButtonConverter" />
+    </ContentPage.Resources>
     
     <ContentPage.Content>
         <Grid>
@@ -32,6 +37,7 @@
                             </StackLayout>
                             <Label Text="{Binding Description}" FontSize="Title"/>
                             <Button Text="View Certification" Command="{Binding ViewCoachCertificationCommand}" Margin="0,10,0,0" />
+                            <Button Text="{Binding IsSuspended, Converter={StaticResource boolToSetAccountStatusButtonConverter}}" Command="{Binding SetSuspendedStatusCommand}" />
                         </StackLayout>
                     </Frame>
                 </Grid>

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Admin/AdminApprovedCoachProfilePage.xaml
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Admin/AdminApprovedCoachProfilePage.xaml
@@ -37,7 +37,7 @@
                             </StackLayout>
                             <Label Text="{Binding Description}" FontSize="Title"/>
                             <Button Text="View Certification" Command="{Binding ViewCoachCertificationCommand}" Margin="0,10,0,0" />
-                            <Button Text="{Binding IsSuspended, Converter={StaticResource boolToSetAccountStatusButtonConverter}}" Command="{Binding SetSuspendedStatusCommand}" />
+                            <Button Text="{Binding IsSuspended, Converter={StaticResource boolToSetAccountStatusButtonConverter}}" Command="{Binding SetSuspendedStatusCommand}" AutomationId="SetCoachAccountStatusButton" />
                         </StackLayout>
                     </Frame>
                 </Grid>

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/NewCoachPage.xaml
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/NewCoachPage.xaml
@@ -62,7 +62,7 @@
                             <Label Text="{Binding FileName}" HorizontalOptions="Center"/>
                         </StackLayout>
 
-                        <Label Text="{Binding ErrorText}" HorizontalOptions="Center" TextColor="Red" AutomationId="ErrorText"/>
+                        <Label Text="{Binding ErrorText}" HorizontalOptions="Center" HorizontalTextAlignment="Center" TextColor="Red" AutomationId="ErrorText"/>
                     </StackLayout>
                     <Button Text="Confirm Account Information" VerticalOptions="EndAndExpand" CornerRadius="0" Command="{Binding SubmitFormCommand}"
                             IsEnabled="{Binding IsBusy, Converter={StaticResource boolToInvertedBoolConverter}}"


### PR DESCRIPTION
JIRA: [BUILT-25](https://champlainsaintlambert.atlassian.net/browse/BUILT-25?atlOrigin=eyJpIjoiYmM1OGNhZmJiOWM5NGVkOWFmYmE1NTQ5MzcxNTlmNTUiLCJwIjoiaiJ9)

## Context
This story allows an admin to suspend a coach's account.

## Changes
- Added button to suspend/unsuspend coach
- Added converter for button text
- Added null checks for every network service call
- Added redirection to login page upon 403
- Added test for suspending account
- Added  model for accountStatus received from API

## Relevant screenshots (Optional)
![image](https://user-images.githubusercontent.com/55009009/151737904-bb5df087-98a2-40fc-a87a-e0e77da67165.png)
