### PR TITLE
Feat/BUILT-70 coach accept/deny new client

### DIFF
--- a/BuiltDifferent.UITest/BuiltDifferent.UITest.csproj
+++ b/BuiltDifferent.UITest/BuiltDifferent.UITest.csproj
@@ -44,6 +44,7 @@
   <ItemGroup>
     <Compile Include="AdminInteractWithCoachAccountsTests.cs" />
     <Compile Include="ClientCriteriaFormTests.cs" />
+    <Compile Include="CoachClientAcceptDenyTests.cs" />
     <Compile Include="ForgotPasswordTests.cs" />
     <Compile Include="CreateAccountTests.cs" />
     <Compile Include="MarkAsDoneMeal.cs" />

--- a/BuiltDifferent.UITest/ClientCriteriaFormTests.cs
+++ b/BuiltDifferent.UITest/ClientCriteriaFormTests.cs
@@ -56,6 +56,7 @@ namespace BuiltDifferent.UITest
        {
            app.Repl();
        }
+
         [Test]
         public void Reach_Selection_Page()
         {
@@ -63,7 +64,7 @@ namespace BuiltDifferent.UITest
 
             if (platform == Platform.Android)
             {
-                app.Tap(e => e.Id("NoResourceEntry-31"));
+                app.Tap(e => e.Marked("FindCoachByName"));
                 app.EnterText(e => e.Marked("CoachNameField"), "Coach Bob");
                 app.DismissKeyboard();
                 app.Tap(e => e.Marked("SearchCoach"));

--- a/BuiltDifferent.UITest/CoachClientAcceptDenyTests.cs
+++ b/BuiltDifferent.UITest/CoachClientAcceptDenyTests.cs
@@ -1,0 +1,170 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xamarin.UITest;
+
+namespace BuiltDifferent.UITest
+{
+    [TestFixture(Platform.Android)]
+    public class CoachClientAcceptDenyTests
+    {
+
+        IApp app;
+        Platform platform;
+
+        public CoachClientAcceptDenyTests(Platform platform)
+        {
+            this.platform = platform;
+        }
+
+        public void LoginCoach()
+        {
+            app = AppInitializer.StartApp(platform);
+
+            app.WaitForElement(e => e.Marked("Login"));
+
+            app.WaitForElement(e => e.Marked("Email"));
+            app.EnterText(e => e.Marked("Email"), "coach");
+
+            app.WaitForElement(e => e.Marked("Password"));
+            app.EnterText(e => e.Marked("Password"), "coach");
+
+            app.DismissKeyboard();
+
+            app.WaitForElement(e => e.Marked("Login"));
+            app.Tap(e => e.Marked("Login"));
+
+        }
+
+        public void LoginClient()
+        {
+            app = AppInitializer.StartApp(platform);
+
+            app.WaitForElement(e => e.Marked("Login"));
+
+            app.WaitForElement(e => e.Marked("Email"));
+            app.EnterText(e => e.Marked("Email"), "janedoe12");
+
+            app.WaitForElement(e => e.Marked("Password"));
+            app.EnterText(e => e.Marked("Password"), "client");
+
+            app.DismissKeyboard();
+
+            app.WaitForElement(e => e.Marked("Login"));
+            app.Tap(e => e.Marked("Login"));
+        }
+
+        //[Test]
+        //public void OpenRepl()
+        //{
+        //    app.Repl();
+        //}
+
+        [Test, Order(1)]
+        public void Canceled_Accept_Client_Request()
+        {
+            if (platform == Platform.Android)
+            {
+                LoginCoach();
+                app.Tap(c => c.Class("AppCompatImageButton"));
+                app.Tap(e => e.Marked("ClientRequests"));
+                app.Tap(e => e.Marked("RequestInfo"));
+                app.Tap(e => e.Marked("AcceptClientButton"));
+                app.WaitForElement(c => c.Marked("Cancel").Parent().Class("AlertDialogLayout"));
+                app.Tap("Cancel");
+                Assert.IsTrue(app.Query(x => x.Marked("ClientNameRequest").Text("Bob Jones")).Any());
+            }
+            else return;
+        }
+
+        [Test, Order(2)]
+        public void Canceled_Deny_Client_Request()
+        {
+            if (platform == Platform.Android)
+            {
+                LoginCoach();
+                app.Tap(c => c.Class("AppCompatImageButton"));
+                app.Tap(e => e.Marked("ClientRequests"));
+                app.Tap(e => e.Marked("RequestInfo"));
+                app.Tap(e => e.Marked("DenyClientButton"));
+                app.WaitForElement(c => c.Marked("Cancel").Parent().Class("AlertDialogLayout"));
+                app.Tap("Cancel");
+                Assert.IsTrue(app.Query(x => x.Marked("ClientNameRequest").Text("Bob Jones")).Any());
+            }
+            else return;
+        }
+
+        [Test, Order(3)]
+        public void Deny_Client_Request()
+        {
+            if (platform == Platform.Android)
+            {
+                LoginCoach();
+                app.Tap(c => c.Class("AppCompatImageButton"));
+                app.Tap(e => e.Marked("ClientRequests"));
+                app.Tap(e => e.Marked("RequestInfo"));
+                app.Tap(e => e.Marked("DenyClientButton"));
+                app.WaitForElement(c => c.Marked("Confirm").Parent().Class("AlertDialogLayout"));
+                app.Tap("Confirm");
+                Assert.IsTrue(app.Query(x => x.Id("message").Text("We'll let the client know that you cannot accept their request at this time.")).Any());
+            }
+            else return;
+        }
+
+        [Test, Order(4)]
+        public void Accept_Client_Request_Ensure_Client_is_found()
+        {
+            if (platform == Platform.Android)
+            {
+                LoginClient();
+                app.Tap(e => e.Marked("FindCoachByName"));
+                app.EnterText(e => e.Marked("CoachNameField"), "Coach Bob");
+                app.DismissKeyboard();
+                app.Tap(e => e.Marked("SearchCoach"));
+                app.Tap(e => e.Marked("CoachInfoName"));
+                app.Tap(e => e.Marked("RequestCoach"));
+                app.WaitForElement(c => c.Marked("OK").Parent().Class("AlertDialogLayout"));
+                app.Tap("OK");
+                app.Tap(c => c.Class("AppCompatImageButton"));
+                app.Tap(c => c.Class("AppCompatImageButton"));
+                app.Tap(e => e.Marked("Log out"));
+
+                LoginCoach();
+                app.Tap(c => c.Class("AppCompatImageButton"));
+                app.Tap(e => e.Marked("ClientRequests"));
+                app.Tap(e => e.Marked("RequestInfo"));
+                app.Tap(e => e.Marked("AcceptClientButton"));
+                app.WaitForElement(c => c.Marked("Confirm").Parent().Class("AlertDialogLayout"));
+                app.Tap("Confirm");
+                app.Tap(c => c.Class("AppCompatImageButton"));
+                app.Tap(c => c.Class("AppCompatImageButton"));
+                app.WaitForElement(c => c.Marked("CoachClients"));
+                app.Tap(c => c.Marked("CoachClients"));
+                Assert.IsTrue(app.Query(x => x.Marked("ClientName").Text("Jane Doe")).Any());
+            }
+            else return;
+        }
+
+        //[Test, Order(4)]
+        //public void Accept_Client_Request()
+        //{
+        //    if (platform == Platform.Android)
+        //    {
+        //        LoginCoach();
+        //        app.Tap(c => c.Class("AppCompatImageButton"));
+        //        app.Tap(e => e.Marked("ClientRequests"));
+        //        app.Tap(e => e.Marked("RequestInfo"));
+        //        app.Tap(e => e.Marked("AcceptClientButton"));
+        //        app.WaitForElement(c => c.Marked("Confirm").Parent().Class("AlertDialogLayout"));
+        //        app.Tap("Confirm");
+        //        Assert.IsTrue(app.Query(x => x.Id("RequestInfo").Text("Get Coaching! You have a new client.")).Any());
+        //    }
+        //    else return;
+        //}
+
+        
+    }
+}

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp.Android/Resources/Resource.designer.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp.Android/Resources/Resource.designer.cs
@@ -14,7 +14,7 @@ namespace BuiltDifferentMobileApp.Droid
 {
 	
 	
-	[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "12.1.0.11")]
+	[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "1.0.0.0")]
 	public partial class Resource
 	{
 		

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/AppShell.xaml
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/AppShell.xaml
@@ -93,12 +93,12 @@
         COACH PAGES
     -->
 
-    <FlyoutItem Title="Clients" IsVisible="{Binding IsVerifiedCoach}">
-        <ShellContent Route="CoachDashboardPage" ContentTemplate="{DataTemplate coachpages:CoachDashboardPage}" />
+    <FlyoutItem Title="Clients" IsVisible="{Binding IsVerifiedCoach}" AutomationId="CoachClients">
+        <ShellContent Route="CoachDashboardPage" ContentTemplate="{DataTemplate coachpages:CoachDashboardPage}"  />
     </FlyoutItem>
-    
-    <FlyoutItem Title="Requests" IsVisible="{Binding IsVerifiedCoach}">
-        <ShellContent Route="CoachClientApprovalPage" ContentTemplate="{DataTemplate coachpages:CoachClientApprovalPage}" />
+
+    <FlyoutItem Title="Requests" IsVisible="{Binding IsVerifiedCoach}"  AutomationId="ClientRequests">
+        <ShellContent Route="CoachClientApprovalPage" ContentTemplate="{DataTemplate coachpages:CoachClientApprovalPage}"/>
     </FlyoutItem>
 
     <FlyoutItem Title="Apply for approval" IsVisible="{Binding IsUnverifiedCoach}">
@@ -142,7 +142,7 @@
     -->
 
     <FlyoutItem Title="Log out">
-        <ShellContent Route="LoginPage" ContentTemplate="{DataTemplate loginpages:LoginPage}" Shell.FlyoutBehavior="Disabled" FlyoutItemIsVisible="False"/>
+        <ShellContent Route="LoginPage" ContentTemplate="{DataTemplate loginpages:LoginPage}" Shell.FlyoutBehavior="Disabled" FlyoutItemIsVisible="False" AutomationId="Log out"/>
     </FlyoutItem>
 
 </Shell>

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/AppShell.xaml
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/AppShell.xaml
@@ -96,6 +96,10 @@
     <FlyoutItem Title="Clients" IsVisible="{Binding IsVerifiedCoach}">
         <ShellContent Route="CoachDashboardPage" ContentTemplate="{DataTemplate coachpages:CoachDashboardPage}" />
     </FlyoutItem>
+    
+    <FlyoutItem Title="Requests" IsVisible="{Binding IsVerifiedCoach}">
+        <ShellContent Route="CoachClientApprovalPage" ContentTemplate="{DataTemplate coachpages:CoachClientApprovalPage}" />
+    </FlyoutItem>
 
     <FlyoutItem Title="Apply for approval" IsVisible="{Binding IsUnverifiedCoach}">
         <ShellContent Route="NewCoachPage" ContentTemplate="{DataTemplate coachpages:NewCoachPage}" />

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/AppShell.xaml.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/AppShell.xaml.cs
@@ -21,6 +21,7 @@ namespace BuiltDifferentMobileApp {
             Routing.RegisterRoute(nameof(AdminMenuPage), typeof(AdminMenuPage));
 
             // Coach pages
+            Routing.RegisterRoute(nameof(CoachClientApprovalPage), typeof(CoachClientApprovalPage));
             Routing.RegisterRoute(nameof(AddWorkoutPage), typeof(AddWorkoutPage));
             Routing.RegisterRoute(nameof(EditWorkoutPage), typeof(EditWorkoutPage));
             Routing.RegisterRoute(nameof(AddMealPage), typeof(AddMealPage));

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/BuiltDifferentMobileApp.csproj
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/BuiltDifferentMobileApp.csproj
@@ -76,6 +76,9 @@
     <EmbeddedResource Update="Views\Coach\AddMealPage.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
+    <EmbeddedResource Update="Views\Coach\CoachClientApprovalPage.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
     <EmbeddedResource Update="Views\Coach\CoachDashboardPage.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Models/ClientApprovalStatus.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Models/ClientApprovalStatus.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BuiltDifferentMobileApp.Models
+{
+    public class ClientApprovalStatus
+    {
+        public string status { get; set; }
+
+        public ClientApprovalStatus(string status)
+        {
+            this.status = status;
+        }
+    }
+}

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Models/RequestClientInfo.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Models/RequestClientInfo.cs
@@ -4,21 +4,25 @@ using System.Text;
 
 namespace BuiltDifferentMobileApp.Models
 {
-    public class Request
+    public class RequestClientInfo
     {
         public int id { get; set; }
         public string status { get; set; }
         public int coachId { get; set; }
         public int clientId { get; set; }
+        public string clientName { get; set; }
+        public string planSelected { get; set; }
         public DateTime approvalDate { get; set; }
         public DateTime requestDate { get; set; }
 
-        public Request(int id, string status, int coachId, int clientId, DateTime approvalDate, DateTime requestDate)
+        public RequestClientInfo(int id, string status, int coachId, int clientId, string clientName, string planSelected, DateTime approvalDate, DateTime requestDate)
         {
             this.id = id;
             this.status = status;
             this.coachId = coachId;
             this.clientId = clientId;
+            this.clientName = clientName;
+            this.planSelected = planSelected;
             this.approvalDate = approvalDate;
             this.requestDate = requestDate;
         }

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Models/RequestDTO.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Models/RequestDTO.cs
@@ -9,12 +9,16 @@ namespace BuiltDifferentMobileApp.Models
         public string status { get; set; }
         public int coachId { get; set; }
         public int clientId { get; set; }
+        public string clientName { get; set; }
+        public string planSelected { get; set; }
 
-        public RequestDTO (string status , int coachId, int clientId)
+        public RequestDTO (string status , int coachId, int clientId,string clientName, string planSelected)
         {
             this.status = status;
             this.coachId = coachId;
             this.clientId = clientId;
+            this.clientName = clientName;
+            this.planSelected = planSelected;
         }
      
     }

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Ressource/AppResource.Designer.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Ressource/AppResource.Designer.cs
@@ -574,6 +574,42 @@ namespace BuiltDifferentMobileApp.Ressource {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No Requests.
+        /// </summary>
+        public static string CoachClientApprovalNoRequests {
+            get {
+                return ResourceManager.GetString("CoachClientApprovalNoRequests", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Client Requests.
+        /// </summary>
+        public static string CoachClientApprovalTitle {
+            get {
+                return ResourceManager.GetString("CoachClientApprovalTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Your Requests.
+        /// </summary>
+        public static string CoachClientApprovalYourRequests {
+            get {
+                return ResourceManager.GetString("CoachClientApprovalYourRequests", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Accept.
+        /// </summary>
+        public static string CoachClientRequestAccept {
+            get {
+                return ResourceManager.GetString("CoachClientRequestAccept", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Board.
         /// </summary>
         public static string CoachDashboardBoard {

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Ressource/AppResource.fr.resx
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Ressource/AppResource.fr.resx
@@ -317,6 +317,21 @@
     <value>Type de repas</value>
     <comment>7-AddMealPage</comment>
   </data>
+  <data name="CoachClientApprovalNoRequests" xml:space="preserve">
+    <value>Aucune demande</value>
+    <comment>17-CoachClientApprovalPage</comment>
+  </data>
+  <data name="CoachClientApprovalTitle" xml:space="preserve">
+    <value>Demandes de clients</value>
+    <comment>17-CoachClientApprovalPage</comment>
+  </data>
+  <data name="CoachClientApprovalYourRequests" xml:space="preserve">
+    <value>Vos demandes de clients</value>
+    <comment>17-CoachClientApprovalPage</comment>
+  </data>
+  <data name="CoachClientRequestAccept" xml:space="preserve">
+    <value>Accepter</value>
+  </data>
   <data name="CoachDashboardBoard" xml:space="preserve">
     <value>Plan</value>
     <comment>9-CoachDashboardPage</comment>

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Ressource/AppResource.resx
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Ressource/AppResource.resx
@@ -337,6 +337,21 @@
     <value>Meal Type</value>
     <comment>7-AddMealPage</comment>
   </data>
+  <data name="CoachClientApprovalNoRequests" xml:space="preserve">
+    <value>No Requests</value>
+    <comment>17-CoachClientApprovalPage</comment>
+  </data>
+  <data name="CoachClientApprovalTitle" xml:space="preserve">
+    <value>Client Requests</value>
+    <comment>17-CoachClientApprovalPage</comment>
+  </data>
+  <data name="CoachClientApprovalYourRequests" xml:space="preserve">
+    <value>Your Requests</value>
+    <comment>17-CoachClientApprovalPage</comment>
+  </data>
+  <data name="CoachClientRequestAccept" xml:space="preserve">
+    <value>Accept</value>
+  </data>
   <data name="CoachDashboardBoard" xml:space="preserve">
     <value>Board</value>
     <comment>9-CoachDashboardPage</comment>

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Services/NetworkServices/APIConstants.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Services/NetworkServices/APIConstants.cs
@@ -26,6 +26,20 @@ namespace BuiltDifferentMobileApp.Services.NetworkServices
             return $"{BaseAddress}/requests";
         }
 
+        /*
+        * Coach Client Accept/Deny URI
+        */
+
+        public static string UpdateApproveDenyRequestUri(int clientId)
+        {
+            return $"{BaseAddress}/requests/applications/{clientId}";
+        }
+
+        public static string GetPendingRequestsUri(int coachId)
+        {
+            return $"{BaseAddress}/requests/coach/pending/{coachId}";
+        }
+
 
         /*
          *  COACH URIS

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Client/ClientCoachSelectionViewModel.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Client/ClientCoachSelectionViewModel.cs
@@ -36,7 +36,7 @@ namespace BuiltDifferentMobileApp.ViewModels.Client
             var user = (Models.Client)accountService.CurrentUser;
             this.clientId = user.id;
             this.clientName = user.name;
-            this.planSelected = CoachingType;
+            planSelected = "Not Specified";
             SendRequest = new AsyncCommand<int>(Request);
             GetCoaches();
         }
@@ -92,7 +92,7 @@ namespace BuiltDifferentMobileApp.ViewModels.Client
                 var routeClientRequests = APIConstants.GetAllRequestsByClient(clientId);
                 var clientRequests = await networkService.GetAsync<List<Request>>(routeClientRequests);
 
-                if (clientRequests == null)
+                if (clientRequests.Count==0)
                 {
                     var routeSendRequest = APIConstants.PostRequestURI();
 

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Client/ClientCoachSelectionViewModel.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Client/ClientCoachSelectionViewModel.cs
@@ -18,6 +18,8 @@ namespace BuiltDifferentMobileApp.ViewModels.Client
     public class ClientCoachSelectionViewModel : ViewModelBase
     {
         private int clientId;
+        private string clientName;
+        private string planSelected;
         private string coachName, gender, coachingType;
         public string CoachName { get => coachName; set => SetProperty(ref coachName, value); }
         public AsyncCommand<int> SendRequest { get; }
@@ -33,6 +35,8 @@ namespace BuiltDifferentMobileApp.ViewModels.Client
             CoachingType = coachingT;
             var user = (Models.Client)accountService.CurrentUser;
             this.clientId = user.id;
+            this.clientName = user.name;
+            this.planSelected = CoachingType;
             SendRequest = new AsyncCommand<int>(Request);
             GetCoaches();
         }
@@ -92,7 +96,7 @@ namespace BuiltDifferentMobileApp.ViewModels.Client
                 {
                     var routeSendRequest = APIConstants.PostRequestURI();
 
-                    var request = new RequestDTO("PENDING",id, clientId);
+                    var request = new RequestDTO("PENDING",id, clientId, clientName, planSelected);
                     var test = JsonConvert.SerializeObject(request);
                     var result = await networkService.PostAsync<HttpResponseMessage>(routeSendRequest, request);
                     var httpCode = result.StatusCode;

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Client/ClientCoachSelectionViewModel.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Client/ClientCoachSelectionViewModel.cs
@@ -92,7 +92,7 @@ namespace BuiltDifferentMobileApp.ViewModels.Client
                 var routeClientRequests = APIConstants.GetAllRequestsByClient(clientId);
                 var clientRequests = await networkService.GetAsync<List<Request>>(routeClientRequests);
 
-                if (clientRequests.Count==0)
+                if (clientRequests.Count == 0)
                 {
                     var routeSendRequest = APIConstants.PostRequestURI();
 
@@ -120,12 +120,6 @@ namespace BuiltDifferentMobileApp.ViewModels.Client
             {
                 return;
             }
-
-
-
-
         }
-
-
     }
 }

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Coach/CoachClientApprovalViewModel.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Coach/CoachClientApprovalViewModel.cs
@@ -35,10 +35,9 @@ namespace BuiltDifferentMobileApp.ViewModels.Coach
         public CoachClientApprovalViewModel()
         {
 
-            //FIGURE WHY its sending a 1 for coachId
-
             this.CoachId = ((Models.Coach)accountService.CurrentUser).id;
             ClientName = "";
+            
             RefreshCommand = new AsyncCommand(FetchPendingRequests);
             RespondToClientRequestAcceptCommand = new AsyncCommand<Models.RequestClientInfo>(RespondToClientRequestAccept);
             RespondToClientRequestDenyCommand = new AsyncCommand<Models.RequestClientInfo>(RespondToClientRequestDeny);

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Coach/CoachClientApprovalViewModel.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Coach/CoachClientApprovalViewModel.cs
@@ -55,7 +55,7 @@ namespace BuiltDifferentMobileApp.ViewModels.Coach
 
             if (response >= 200 && response <= 299)
             {
-                await Application.Current.MainPage.DisplayAlert("Client Request Accepted", "Get Coaching! you have a new client.", "OK");
+                await Application.Current.MainPage.DisplayAlert("Client Request Accepted", "Get Coaching! You have a new client.", "OK");
                 FetchPendingRequests();
             }
             else
@@ -75,7 +75,7 @@ namespace BuiltDifferentMobileApp.ViewModels.Coach
 
             if (response >= 200 && response <= 299)
             {
-                await Application.Current.MainPage.DisplayAlert("Client Request Denied", "We'll let the client know that you cannot accept his request at this time.", "OK");
+                await Application.Current.MainPage.DisplayAlert("Client Request Denied", "We'll let the client know that you cannot accept their request at this time.", "OK");
                 FetchPendingRequests();
             }
             else

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Coach/CoachClientApprovalViewModel.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Coach/CoachClientApprovalViewModel.cs
@@ -1,0 +1,112 @@
+﻿using BuiltDifferentMobileApp.Models;
+using BuiltDifferentMobileApp.Ressource;
+using BuiltDifferentMobileApp.Services.AccountServices;
+using BuiltDifferentMobileApp.Services.NetworkServices;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Xamarin.CommunityToolkit.ObjectModel;
+using Xamarin.Forms;
+
+namespace BuiltDifferentMobileApp.ViewModels.Coach
+{
+    public class CoachClientApprovalViewModel : ViewModelBase
+    {
+        private IAccountService accountService = AccountService.Instance;
+        private INetworkService<HttpResponseMessage> networkService = NetworkService<HttpResponseMessage>.Instance;
+
+        public ObservableRangeCollection<Models.RequestClientInfo> ClientRequests { get; set; }
+        public Models.Request SelectedRequest { get; set; }
+
+        public string DenyButtonText { get; set; }
+        public string AcceptButtonText { get; set; }
+
+        public AsyncCommand RefreshCommand { get; set; }
+        public string ButtonText { get; set; }
+        public int ClientId { get; set; }
+        public int CoachId { get; set; }
+        public string ClientName { get; set; }
+
+        public AsyncCommand<Models.RequestClientInfo> RespondToClientRequestAcceptCommand { get; set; }
+        public AsyncCommand<Models.RequestClientInfo> RespondToClientRequestDenyCommand { get; set; }
+
+        public CoachClientApprovalViewModel()
+        {
+
+            //FIGURE WHY its sending a 1 for coachId
+
+            this.CoachId = ((Models.Coach)accountService.CurrentUser).id;
+            ClientName = "";
+            RefreshCommand = new AsyncCommand(FetchPendingRequests);
+            RespondToClientRequestAcceptCommand = new AsyncCommand<Models.RequestClientInfo>(RespondToClientRequestAccept);
+            RespondToClientRequestDenyCommand = new AsyncCommand<Models.RequestClientInfo>(RespondToClientRequestDeny);
+            FetchPendingRequests();
+        }
+
+        private async Task RespondToClientRequestAccept(Models.RequestClientInfo request)
+        {
+            int response;
+            var accepted = await Application.Current.MainPage.DisplayAlert("Accept Client", "Are you sure you want to accept this client?", "Confirm", "Cancel");
+
+            if (!accepted) return;
+
+            response = (int)await networkService.PutAsyncHttpResponseMessage(APIConstants.UpdateApproveDenyRequestUri(request.clientId), new ClientApprovalStatus(ApprovalConstants.APPROVED));
+
+            if (response >= 200 && response <= 299)
+            {
+                await Application.Current.MainPage.DisplayAlert("Client Request Accepted", "Get Coaching! you have a new client.", "OK");
+                FetchPendingRequests();
+            }
+            else
+            {
+                await Application.Current.MainPage.DisplayAlert($"Server Error ({response})", "Could not accept/deny client. Please try again.", "OK");
+            }
+        }
+
+        private async Task RespondToClientRequestDeny(Models.RequestClientInfo request)
+        {
+            int response;
+            var accepted = await Application.Current.MainPage.DisplayAlert("Deny Client", "Are you sure you want to deny this client?", "Confirm", "Cancel");
+
+            if (!accepted) return;
+
+            response = (int)await networkService.PutAsyncHttpResponseMessage(APIConstants.UpdateApproveDenyRequestUri(request.clientId), new ClientApprovalStatus(ApprovalConstants.DENIED));
+
+            if (response >= 200 && response <= 299)
+            {
+                await Application.Current.MainPage.DisplayAlert("Client Request Denied", "We'll let the client know that you cannot accept his request at this time.", "OK");
+                FetchPendingRequests();
+            }
+            else
+            {
+                await Application.Current.MainPage.DisplayAlert($"Server Error ({response})", "Could not accept/deny client. Please try again.", "OK");
+            }
+        }
+
+    public async Task FetchPendingRequests()
+        {
+            IsBusy = true;
+
+            var requests = await networkService.GetAsync<List<Models.RequestClientInfo>>(APIConstants.GetPendingRequestsUri(CoachId));
+
+            if (requests == null)
+            {
+                ClientRequests = new ObservableRangeCollection<Models.RequestClientInfo>();
+            }
+            else if (requests.Count > 0)
+            {
+                ClientRequests = new ObservableRangeCollection<Models.RequestClientInfo>(requests);
+            }
+            else
+            {
+                ClientRequests = new ObservableRangeCollection<Models.RequestClientInfo>();
+            }
+
+            OnPropertyChanged("ClientRequests");
+
+            IsBusy = false;
+        }
+    }
+}

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Client/ClientCoachCriteriasPage.xaml
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Client/ClientCoachCriteriasPage.xaml
@@ -57,7 +57,7 @@
                     <Grid  >
                         <behaviors:Expander>
                             <behaviors:Expander.Header>
-                                <Label Text="{x:Static resource:AppResource.FindACoachByNameLabel}"  FontSize="18"  FontAttributes="Bold" HorizontalTextAlignment="Center" TextColor="{StaticResource DarkGrey}"/>
+                                <Label Text="{x:Static resource:AppResource.FindACoachByNameLabel}"  FontSize="18"  FontAttributes="Bold" HorizontalTextAlignment="Center" TextColor="{StaticResource DarkGrey}" AutomationId="FindCoachByName"/>
 
                             </behaviors:Expander.Header>
                             <behaviors:Expander.ContentTemplate>

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Client/ClientCoachSelectionPage.xaml
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Client/ClientCoachSelectionPage.xaml
@@ -37,7 +37,7 @@
                                     <Grid >
                                         <StackLayout Grid.Row="0" Grid.Column="0" Orientation="Horizontal">
                                             <Image Source="https://pngset.com/images/katie-notopoulos-katienotopoulos-i-write-about-tech-round-profile-image-placeholder-text-number-symbol-word-transparent-png-201415.png" HeightRequest="40"/>
-                                            <Label Text="{Binding name}" FontAttributes="Bold"
+                                                <Label AutomationId="CoachInfoName" Text="{Binding name}" FontAttributes="Bold"
                                         FontSize="Medium" LineBreakMode="TailTruncation" VerticalOptions="Center"/>
                                         </StackLayout>
 
@@ -79,6 +79,7 @@
                                         Padding="2"
                                         CornerRadius="10"  
                                                      Command="{Binding Source={x:Reference SelectionPage}, Path=BindingContext.SendRequest}" CommandParameter="{Binding id}"
+                                                    AutomationId="RequestCoach"
                                         />
                                              
                                             </StackLayout>

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/CoachClientApprovalPage.xaml
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/CoachClientApprovalPage.xaml
@@ -1,0 +1,86 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:behaviors="http://xamarin.com/schemas/2020/toolkit"
+             xmlns:resource="clr-namespace:BuiltDifferentMobileApp.Ressource"
+             x:Class="BuiltDifferentMobileApp.Views.Coach.CoachClientApprovalPage"
+             x:Name="MyClientApprovalPage"
+             Title="{x:Static resource:AppResource.CoachClientApprovalTitle}">
+
+    <ContentPage.Content>
+        <RefreshView IsRefreshing="{Binding IsBusy}"
+                     Command="{Binding RefreshCommand}">
+            <StackLayout BackgroundColor="{StaticResource PageBackground}" Padding="12,12,10,12" Margin="0">
+                <Label Text="{x:Static resource:AppResource.CoachClientApprovalYourRequests}" FontSize="26" FontAttributes="Bold" HorizontalTextAlignment="Center" TextColor="{StaticResource DarkGrey}"/>
+
+                <CollectionView ItemsSource="{Binding ClientRequests}"
+                                ItemSizingStrategy="MeasureAllItems"
+                                SelectedItem="{Binding SelectedRequest}"
+                                SelectionMode="Single"
+                                SelectionChangedCommand="{Binding SelectedrequestCommand}">
+
+                    <CollectionView.ItemTemplate>
+                        <DataTemplate>
+                            <Grid Padding="5">
+                                <behaviors:Expander>
+                                    <behaviors:Expander.Header>
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="Auto"/>
+                                                <ColumnDefinition Width="Auto"/>
+                                                <ColumnDefinition Width="Auto"/>
+                                                <ColumnDefinition />
+                                            </Grid.ColumnDefinitions>
+                                            <Grid.RowDefinitions>
+                                                <RowDefinition Height="Auto" />
+                                            </Grid.RowDefinitions>
+                                            <Image Grid.Column="0" Source="icon_about.png" VerticalOptions="Center" HorizontalOptions="EndAndExpand"/>
+                                            <Label 
+                                                Grid.Column="1" 
+                                                VerticalOptions="Center"
+                                                Text="{Binding clientName}"
+                                                FontAttributes="Bold"
+                                                FontSize="Medium" />
+                                            <StackLayout Orientation="Horizontal" Grid.Column="3" VerticalOptions="Center" HorizontalOptions="End">
+                                                <Button Command="{Binding Source={x:Reference MyClientApprovalPage}, Path=BindingContext.RespondToClientRequestDenyCommand}" CommandParameter="{Binding .}" Text="{x:Static resource:AppResource.AdminCoachApprovalDeny}" AutomationId="DenyClientButton"/>
+                                                <Button Command="{Binding Source={x:Reference MyClientApprovalPage}, Path=BindingContext.RespondToClientRequestAcceptCommand}" CommandParameter="{Binding .}" Text="{x:Static resource:AppResource.CoachClientRequestAccept}" AutomationId="AcceptClientButton"/>
+                                            </StackLayout>
+                                        </Grid>
+                                    </behaviors:Expander.Header>
+                                    
+                                    <behaviors:Expander.ContentTemplate>
+                                        <DataTemplate>
+                                            <Grid>
+                                                <Grid.RowDefinitions>
+                                                    <RowDefinition Height="Auto" />
+                                                    <RowDefinition Height="Auto"/>
+                                                    <RowDefinition/>
+                                                </Grid.RowDefinitions>
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="Auto"/>
+                                                    <ColumnDefinition />
+                                                </Grid.ColumnDefinitions>
+
+                                                <StackLayout Grid.Row="0" Grid.Column="0" Orientation="Horizontal">
+                                                    <Label Text="Plan:" LineBreakMode="TailTruncation" FontSize="Body" FontAttributes="Bold"/>
+                                                    <Label Text="{Binding planSelected}" LineBreakMode="TailTruncation" FontSize="Body"/>
+                                                </StackLayout>
+                                                <StackLayout Grid.Row="1" Grid.Column="0" Orientation="Horizontal">
+                                                    <Label Text="Data Requested:" LineBreakMode="TailTruncation" FontSize="Body" FontAttributes="Bold"/>
+                                                    <Label Text="{Binding requestDate}" LineBreakMode="TailTruncation" FontSize="Body"/>
+                                                </StackLayout>
+                                            </Grid>
+                                        </DataTemplate>
+                                    </behaviors:Expander.ContentTemplate>
+                                </behaviors:Expander>
+                            </Grid>
+                        </DataTemplate>
+                    </CollectionView.ItemTemplate>
+                    <CollectionView.EmptyView>
+                        <Label Text="{x:Static resource:AppResource.CoachClientApprovalNoRequests}" />
+                    </CollectionView.EmptyView>
+                </CollectionView>
+            </StackLayout>
+        </RefreshView>
+    </ContentPage.Content>
+</ContentPage>

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/CoachClientApprovalPage.xaml
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/CoachClientApprovalPage.xaml
@@ -34,13 +34,13 @@
                                             <Grid.RowDefinitions>
                                                 <RowDefinition Height="Auto" />
                                             </Grid.RowDefinitions>
-                                            <Image Grid.Column="0" Source="icon_about.png" VerticalOptions="Center" HorizontalOptions="EndAndExpand"/>
+                                            <Image Grid.Column="0" Source="icon_about.png" VerticalOptions="Center" HorizontalOptions="EndAndExpand" AutomationId="RequestInfo"/>
                                             <Label 
                                                 Grid.Column="1" 
                                                 VerticalOptions="Center"
                                                 Text="{Binding clientName}"
                                                 FontAttributes="Bold"
-                                                FontSize="Medium" />
+                                                FontSize="Medium" AutomationId="ClientNameRequest" />
                                             <StackLayout Orientation="Horizontal" Grid.Column="3" VerticalOptions="Center" HorizontalOptions="End">
                                                 <Button Command="{Binding Source={x:Reference MyClientApprovalPage}, Path=BindingContext.RespondToClientRequestDenyCommand}" CommandParameter="{Binding .}" Text="{x:Static resource:AppResource.AdminCoachApprovalDeny}" AutomationId="DenyClientButton"/>
                                                 <Button Command="{Binding Source={x:Reference MyClientApprovalPage}, Path=BindingContext.RespondToClientRequestAcceptCommand}" CommandParameter="{Binding .}" Text="{x:Static resource:AppResource.CoachClientRequestAccept}" AutomationId="AcceptClientButton"/>

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/CoachClientApprovalPage.xaml.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/CoachClientApprovalPage.xaml.cs
@@ -1,0 +1,22 @@
+﻿using BuiltDifferentMobileApp.ViewModels.Coach;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace BuiltDifferentMobileApp.Views.Coach
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class CoachClientApprovalPage : ContentPage
+    {
+        public CoachClientApprovalPage()
+        {
+            InitializeComponent();
+            BindingContext = new CoachClientApprovalViewModel();
+        }
+    }
+}

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/CoachDashboardPage.xaml
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/CoachDashboardPage.xaml
@@ -45,7 +45,7 @@
 
                                         <StackLayout Grid.Row="0" Grid.Column="0" Orientation="Horizontal">
                                             <Image Source="https://pngset.com/images/katie-notopoulos-katienotopoulos-i-write-about-tech-round-profile-image-placeholder-text-number-symbol-word-transparent-png-201415.png" HeightRequest="40"/>
-                                            <Label Text="{Binding name}" LineBreakMode="TailTruncation" VerticalOptions="Center" FontSize="Large"/>
+                                            <Label Text="{Binding name}" LineBreakMode="TailTruncation" VerticalOptions="Center" FontSize="Large" AutomationId="ClientName"/>
                                         </StackLayout>
 
                                         <Label Grid.Row="0" Grid.Column="1" Text="10%" HorizontalOptions="Center" LineBreakMode="TailTruncation" VerticalOptions="Center" FontSize="Large"/>


### PR DESCRIPTION
JIRA: [BUILT-70](https://champlainsaintlambert.atlassian.net/browse/BUILT-70?atlOrigin=eyJpIjoiNzE0ZGJlNjBjNTMxNDYxOWI3ZWU5NWJkZTJkYTAzNmQiLCJwIjoiaiJ9)

## Context
This story is the frontend allowing an active coach to accept or deny a pending client requests.

There have been some changes tothe modelks including Client and RequestDTO in order to include planSelected and clientName. 
Once a client has been accept the coach will then gain acces to that client on their client page. 
A client dashboard will then also change to have a plan dashboard awaiting a plan to be added. 

If a client request is denied the client will be redirected to the coach criteria page once again. 

## Changes

## Relevant screenshots (Optional)
![Screenshot 2022-02-07 184031](https://user-images.githubusercontent.com/54686732/152891581-fefbad43-d0e0-4806-b35b-3c448446633c.png)
![Screenshot 2022-02-07 184059](https://user-images.githubusercontent.com/54686732/152891585-19fbaa15-4dc6-4110-ad06-79e487f105a8.png)
![Screenshot 2022-02-07 181613](https://user-images.githubusercontent.com/54686732/152891586-0327624c-74ec-4d1a-961e-65b6aec08f42.png)

