### PR TITLE
feat(BUILT-32): Remove Client from service

### DIFF
--- a/BuiltDifferent.UITest/BuiltDifferent.UITest.csproj
+++ b/BuiltDifferent.UITest/BuiltDifferent.UITest.csproj
@@ -44,6 +44,7 @@
   <ItemGroup>
     <Compile Include="AdminInteractWithCoachAccountsTests.cs" />
     <Compile Include="ClientCriteriaFormTests.cs" />
+    <Compile Include="ClientRemoveTests.cs" />
     <Compile Include="ForgotPasswordTests.cs" />
     <Compile Include="CreateAccountTests.cs" />
     <Compile Include="MarkAsDoneMeal.cs" />

--- a/BuiltDifferent.UITest/ClientRemoveTests.cs
+++ b/BuiltDifferent.UITest/ClientRemoveTests.cs
@@ -1,0 +1,92 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using Xamarin.UITest;
+
+namespace BuiltDifferent.UITest
+{
+    [TestFixture(Platform.Android)]
+    //[TestFixture(Platform.iOS)]
+    public class ClientRemoveTests
+    {
+        IApp app;
+        Platform platform;
+
+        public ClientRemoveTests(Platform platform)
+        {
+            this.platform = platform;
+        }
+
+        [SetUp]
+        public void BeforeEachTest()
+        {
+            app = AppInitializer.StartApp(platform);
+
+            // Login
+            app.WaitForElement(e => e.Marked("Email"), "coach");
+            app.EnterText(e => e.Marked("Email"), "coach");
+
+            app.WaitForElement(e => e.Marked("Password"), "coach");
+            app.EnterText(e => e.Marked("Password"), "coach");
+
+            app.DismissKeyboard();
+
+            app.WaitForElement(e => e.Marked("Login"));
+            app.Tap(e => e.Marked("Login"));
+        }
+
+        private void SaveScreenshot([CallerMemberName] string title = "", [CallerLineNumber] int lineNumber = -1)
+        {
+            FileInfo screenshot = app.Screenshot(title);
+            if (TestEnvironment.IsTestCloud == false)
+            {
+                File.Move(screenshot.FullName, Path.Combine(screenshot.DirectoryName, $"{title}-{lineNumber}{screenshot.Extension}"));
+            }
+        }
+
+        [Test, Order(1)]
+        public void Canceled_Client_Delete()
+        {
+            if (platform == Platform.Android)
+            {
+                app.SwipeRightToLeft(e => e.Marked("Client"));
+                app.WaitForElement(c => c.Marked("Cancel").Parent().Class("AlertDialogLayout"));
+                app.Tap("Cancel");
+                Assert.IsTrue(app.Query(x => x.Marked("ClientName").Text("Bob Jones")).Any());
+            }
+            else return;
+        }
+
+        [Test, Order(2)]
+        public void Canceled_Client_Remove()
+        {
+            if (platform == Platform.Android)
+            {
+                if (platform == Platform.Android)
+                {
+
+                    app.SwipeRightToLeft(e => e.Marked("Client"));
+                    app.WaitForElement(c => c.Marked("Cancel").Parent().Class("AlertDialogLayout"));
+                    app.Tap("Confirm");
+                    app.WaitForElement(c => c.Marked("OK").Parent().Class("AlertDialogLayout"));
+                    app.Tap("OK");
+                    Assert.IsFalse(app.Query(x => x.Marked("ClientName").Text("Bob Jones")).Any());
+                }
+                else return;
+            }
+        }
+        //will look at for IOS testing(will replicate what is seen on actual physical device
+        //to find out tree and ids
+
+        //[Test]
+        //public void OpenRepl()
+        //{
+        //    app.Repl();
+        //}
+    }
+}

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Models/ClientProfileDTO.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Models/ClientProfileDTO.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace BuiltDifferentMobileApp.Models
 {
-    class ClientProfileDTO 
+    public class ClientProfileDTO 
     {
         public string name { get; set; }
         public int userId { get; set; }

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Models/ClientRemoveDTO.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Models/ClientRemoveDTO.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BuiltDifferentMobileApp.Models
+{
+    public class ClientRemoveDTO
+    {
+        public int clientId { get; set; }
+        public int coachId { get; set; }
+
+        public ClientRemoveDTO(int clientId, int coachId)
+        {
+            this.clientId = clientId;
+            this.coachId = coachId;
+        }
+    }
+}

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Services/NetworkServices/APIConstants.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Services/NetworkServices/APIConstants.cs
@@ -122,6 +122,11 @@ namespace BuiltDifferentMobileApp.Services.NetworkServices
             return $"{BaseAddress}/coach/{coachId}/clients";
         }
 
+        public static string UpdateClientRemoveFromServiceUri(int clientId, int coachId)
+        {
+            return $"{BaseAddress}/coaches/{coachId}/clients/remove/{clientId}";
+        }
+
         public static string GetRegisterNewAccountUri() {
             return $"{BaseAddress}/register";
         }

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Client/ClientCoachSelectionViewModel.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Client/ClientCoachSelectionViewModel.cs
@@ -99,7 +99,7 @@ namespace BuiltDifferentMobileApp.ViewModels.Client
 
                     if (httpCode == System.Net.HttpStatusCode.OK)
                     {
-                        await Application.Current.MainPage.DisplayAlert("Request Sent Successfully", "Wait For your Coach to respond", "OK");
+                        await Application.Current.MainPage.DisplayAlert("Request Sent Successfully", "Wait for your Coach to respond", "OK");
                         
                     } else
                     {

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Coach/CoachDashboardPageViewModel.cs
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/ViewModels/Coach/CoachDashboardPageViewModel.cs
@@ -1,4 +1,5 @@
-﻿using BuiltDifferentMobileApp.Services.AccountServices;
+﻿using BuiltDifferentMobileApp.Models;
+using BuiltDifferentMobileApp.Services.AccountServices;
 using BuiltDifferentMobileApp.Services.NetworkServices;
 using BuiltDifferentMobileApp.Views.Coach;
 using System;
@@ -30,6 +31,7 @@ namespace BuiltDifferentMobileApp.ViewModels.Coach {
 
         public AsyncCommand ViewMyProfileCommand { get; }
         public AsyncCommand RefreshCommand { get; }
+        public AsyncCommand<Models.Client> RemoveClientCommand { get; }
         public AsyncCommand<Models.Client> ViewClientsBoardCommand { get; }
 
         public CoachDashboardPageViewModel() {
@@ -37,6 +39,7 @@ namespace BuiltDifferentMobileApp.ViewModels.Coach {
             ViewMyProfileCommand = new AsyncCommand(accountService.ViewMyProfileCommand);
             RefreshCommand = new AsyncCommand(FetchClients);
             ViewClientsBoardCommand = new AsyncCommand<Models.Client>(ViewClientsBoard);
+            RemoveClientCommand = new AsyncCommand<Models.Client>(RemoveClient);
 
             FetchClients();
         }
@@ -56,6 +59,31 @@ namespace BuiltDifferentMobileApp.ViewModels.Coach {
             if(client == null || IsBusy) return;
 
             await Shell.Current.GoToAsync($"{nameof(CoachMenuPage)}?ClientId={client.id}&ClientName={client.name}");
+        }
+
+
+        private async Task RemoveClient(Models.Client client)
+        {
+            IsBusy = true;
+            int coachId = ((Models.Coach)accountService.CurrentUser).id;
+            int response;
+            var accepted = await Application.Current.MainPage.DisplayAlert("Remove Client", "Are you sure you want to remove this client?", "Confirm", "Cancel");
+
+            if (!accepted) return;
+            ClientRemoveDTO removeClientInfo = new ClientRemoveDTO(client.id, 0);
+
+            response = (int)await networkService.PutAsyncHttpResponseMessage(APIConstants.UpdateClientRemoveFromServiceUri(client.id, coachId),  removeClientInfo);
+
+            if (response >= 200 && response <= 299)
+            {
+                await Application.Current.MainPage.DisplayAlert("Client Removed", "We'll let the client know that they have been removed from your services.", "OK");
+                FetchClients();
+            }
+            else
+            {
+                await Application.Current.MainPage.DisplayAlert($"Server Error ({response})", "Could not remove the client. Please try again.", "OK");
+            }
+            IsBusy = false;
         }
 
         public async Task FetchClients() {

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Client/ClientCoachCriteriasPage.xaml
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Client/ClientCoachCriteriasPage.xaml
@@ -3,12 +3,6 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" xmlns:behaviors="http://xamarin.com/schemas/2020/toolkit"
              x:Class="BuiltDifferentMobileApp.Views.Client.ClientCoachCriteriasPage"
              xmlns:resource="clr-namespace:BuiltDifferentMobileApp.Ressource">
-    <ContentPage.ToolbarItems>
-        <ToolbarItem Text="{x:Static resource:AppResource.ProfileTitle}" Command="{Binding ViewMyProfileCommand}">
-            <ToolbarItem.IconImageSource>
-                <FontImageSource FontFamily="FAS" Glyph="&#xf2bd;"/>
-            </ToolbarItem.IconImageSource>        </ToolbarItem>
-    </ContentPage.ToolbarItems>
 
     <ContentPage.Content>
         

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/CoachDashboardPage.xaml
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/CoachDashboardPage.xaml
@@ -41,7 +41,7 @@
                                     </SwipeItems>
                                 </SwipeView.RightItems>
                                 <StackLayout>
-                                <Frame BorderColor="Black" BackgroundColor="White" CornerRadius="0" Margin="0" Padding="10">
+                                <Frame BorderColor="Black" BackgroundColor="White" CornerRadius="0" Margin="0" Padding="10" AutomationId="Client">
                                     <Grid>
                                         <Grid.RowDefinitions>
                                             <RowDefinition />
@@ -54,7 +54,7 @@
 
                                         <StackLayout Grid.Row="0" Grid.Column="0" Orientation="Horizontal">
                                             <Image Source="https://pngset.com/images/katie-notopoulos-katienotopoulos-i-write-about-tech-round-profile-image-placeholder-text-number-symbol-word-transparent-png-201415.png" HeightRequest="40"/>
-                                            <Label Text="{Binding name}" LineBreakMode="TailTruncation" VerticalOptions="Center" FontSize="Large"/>
+                                                <Label Text="{Binding name}" LineBreakMode="TailTruncation" VerticalOptions="Center" FontSize="Large" AutomationId="ClientName"/>
                                         </StackLayout>
 
                                         <Label Grid.Row="0" Grid.Column="1" Text="10%" HorizontalOptions="Center" LineBreakMode="TailTruncation" VerticalOptions="Center" FontSize="Large"/>

--- a/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/CoachDashboardPage.xaml
+++ b/BuiltDifferentMobileApp/BuiltDifferentMobileApp/Views/Coach/CoachDashboardPage.xaml
@@ -31,7 +31,16 @@
 
                     <CollectionView.ItemTemplate>
                         <DataTemplate>
-                            <StackLayout>
+                            <SwipeView>
+                                <SwipeView.RightItems>
+                                    <SwipeItems Mode="Execute">
+                                        <SwipeItem Text="Delete" 
+                                           BackgroundColor="{StaticResource RedSecondary }"
+                                                   Command="{Binding Source={x:Reference MyCoachDashboardPage}, Path=BindingContext.RemoveClientCommand}" 
+                                                   CommandParameter="{Binding .}"/>
+                                    </SwipeItems>
+                                </SwipeView.RightItems>
+                                <StackLayout>
                                 <Frame BorderColor="Black" BackgroundColor="White" CornerRadius="0" Margin="0" Padding="10">
                                     <Grid>
                                         <Grid.RowDefinitions>
@@ -55,6 +64,7 @@
                                     </Grid>
                                 </Frame>
                             </StackLayout>
+                            </SwipeView>
                         </DataTemplate>
                     </CollectionView.ItemTemplate>
 


### PR DESCRIPTION
JIRA: [BUILT-32](https://champlainsaintlambert.atlassian.net/browse/BUILT-32?atlOrigin=eyJpIjoiNTE0M2MwMzU3OTc4NDQ0N2I4MmNjNTk0ODk5ZTRmNWEiLCJwIjoiaiJ9)

## Context
This story aims to allow coaches to remove a client from their service if they wish to cease their services. 
Once this action  has been perfomed a confirmation will apear ensuring the change to be made. 
When the client logs back into their account they are automatically redirected to the CoachSelection page as it was once they first created their account(coachless)

## Changes
- Each Client now has a swipeRight element
- AClientRemoveDTO including the coachId and clientId.
## Relevant screenshots (Optional)
![Screenshot 2022-02-08 143828](https://user-images.githubusercontent.com/54686732/153071475-cfbff0bc-dbef-47b0-8d17-db9b87026d07.png)
![Screenshot 2022-02-08 143816](https://user-images.githubusercontent.com/54686732/153071476-fdb505e2-4775-4985-b66e-767a1b38cb32.png)
![Screenshot 2022-02-08 152655](https://user-images.githubusercontent.com/54686732/153071477-2a241d3c-330d-45c9-a6bf-c0bf6a0ec8dd.png)

